### PR TITLE
create sequence_transform_map_key_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ Sequence-Transform is a user library for QMK that enables a rich declarative rul
 - Fork the Ikcelaks/qmk_sequence_transform repo
 - From a terminal with the current working directory set to your keymap directory (example: `qmk_userspace/keyboard/moonlander/keymaps/ikcelaks`), run this
 command to add the library as a git submodule:<br/>
-`git submodule add git@github.com:Ikcelaks/qmk_sequence_transform.git sequence_transform`
+`git submodule add git@github.com:{Your Github Username}/qmk_sequence_transform.git sequence_transform`
+- Add ```#include "sequence_transform/sequence_transform.h"``` to your list of includes.
 - Wherever you are defining the custom keycodes for your keymap, make sure that your magic / special keys are defined consecutively and add the following define:
 `#define SEQUENCE_TRANSFORM_SPECIAL_KEY_0 {US_SPEC1}` (where `{US_SPEC1}` is whatever name you gave to the first of the consecutive special key keycodes).
 - In the `process_record_user` function of your `keymap.c` file, add the following (or equivalent):<br/>
 ```if (!process_context_magic(keycode, record)) return false;```
+- Add these lines to your `rules.mk` file:<br/>
+```
+        SRC += sequence_transform/sequence_transform.c
+        SRC += sequence_transform/utils.c
+```
 
 ## Make Pull Request
 These instructions are for what I believe is the most flexible way to make Pull Requests.
@@ -20,3 +26,21 @@ These instructions are for what I believe is the most flexible way to make Pull 
 - Make your changes in that branch, commit them, and publish the branch to your GitHub fork.
 - In GitHub, you should see a banner message suggesting that you create a Pull Request with your new branch. Once you're ready for others to look at your code,
 click the button to create the PR.
+
+# User Guide
+THIS LIBRARY IS NOT FINALIZED. A user who isn't looking to get involved in development should only use this right now if they want to test things out and are
+willing to deal with frequent breaking design changes.
+- From a terminal with the current working directory set to your keymap directory (example: `qmk_userspace/keyboard/moonlander/keymaps/ikcelaks`), run this
+command to add the library as a git submodule (no need to create a fork first):<br/>
+`git submodule add https://github.com/ikcelaks/qmk_sequence_transform.git sequence_transform`
+- Wherever you are defining the custom keycodes for your keymap, make sure that your magic / special keys are defined consecutively and add the following define:
+`#define SEQUENCE_TRANSFORM_SPECIAL_KEY_0 {US_SPEC1}` (where `{US_SPEC1}` is whatever name you gave to the first of the consecutive special key keycodes).
+- Add ```#include "sequence_transform/sequence_transform.h"``` to your list of includes.
+- In the `process_record_user` function of your `keymap.c` file, add the following (or equivalent):<br/>
+```if (!process_context_magic(keycode, record)) return false;```
+- Create a config file and rules file for the generator. DETAILED INSTRUCTIONS NOT YET AVAILABLE, because this is not finalized yet.
+- Add these lines to your `rules.mk` file:<br/>
+```
+        SRC += sequence_transform/sequence_transform.c
+        SRC += sequence_transform/utils.c
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # qmk_sequence_transform
 Sequence-Transform is a user library for QMK that enables a rich declarative ruleset for transforming a sequence of keypresses into any output you would like.
 
-# Usage
-Add this library as a git submodule inside your keymap or user folder with the following command:
+# Developer Guide
+## Setup Environment
+- Fork the Ikcelaks/qmk_sequence_transform repo
+- From a terminal with the current working directory set to your keymap directory (example: `qmk_userspace/keyboard/moonlander/keymaps/ikcelaks`), run this
+command to add the library as a git submodule:<br/>
 `git submodule add git@github.com:Ikcelaks/qmk_sequence_transform.git sequence_transform`
+- Wherever you are defining the custom keycodes for your keymap, make sure that your magic / special keys are defined consecutively and add the following define:
+`#define SEQUENCE_TRANSFORM_SPECIAL_KEY_0 {US_SPEC1}` (where `{US_SPEC1}` is whatever name you gave to the first of the consecutive special key keycodes).
+- In the `process_record_user` function of your `keymap.c` file, add the following (or equivalent):<br/>
+```if (!process_context_magic(keycode, record)) return false;```
+
+## Make Pull Request
+These instructions are for what I believe is the most flexible way to make Pull Requests.
+- Create a branch in the sequence_transform repo. Your editor will probably fascilitate this, but you can also run the following command in a terminal in the
+`sequence_transform` directory in your keymap directory:<br/>
+`git checkout -b [new_branch_name]`
+- Make your changes in that branch, commit them, and publish the branch to your GitHub fork.
+- In GitHub, you should see a banner message suggesting that you create a Pull Request with your new branch. Once you're ready for others to look at your code,
+click the button to create the PR.

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -14,7 +14,6 @@
 #include "keycode_config.h"
 #include "send_string.h"
 #include "action_util.h"
-#include "../general/custom_keys.h"
 #include "print.h"
 #include "utils.h"
 
@@ -49,16 +48,6 @@ static uint16_t key_buffer_size = 1;
 static trie_t trie = {
     SEQUENCE_TRANSFORM_DICTIONARY_SIZE,  sequence_transform_data,  COMPLETIONS_SIZE, sequence_transform_completions_data
 };
-
-
-// Default implementation of sequence_transform_map_key_user().
-__attribute__((weak)) bool sequence_transform_map_key_user(uint16_t* keycode, keyrecord_t* record, uint8_t* mods) {
-    // Assume that special keys have keycodes ranging from SEQUENCE_TRANSFORM_SPECIAL_KEY_0 to SEQUENCE_TRANSFORM_SPECIAL_KEY_0 + SPECIAL_KEY_COUNT - 1
-    if (*keycode >= SEQUENCE_TRANSFORM_SPECIAL_KEY_0 && *keycode < SEQUENCE_TRANSFORM_SPECIAL_KEY_0 + SPECIAL_KEY_COUNT) {
-        *keycode = *keycode - SEQUENCE_TRANSFORM_SPECIAL_KEY_0 + SPECIAL_KEY_TRIECODE_0;
-    }
-    return true;
-}
 
 /**
  * @brief determine if context_magic should process this keypress,
@@ -161,7 +150,8 @@ bool process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods)
         reset_buffer();
         return false;
     }
-    return sequence_transform_map_key_user(keycode, record, mods);
+
+    return true;
 }
 
 /**
@@ -363,7 +353,7 @@ bool perform_magic()
  * @return true Continue processing keycodes, and send to host
  * @return false Stop processing keycodes, and don't send to host
  */
-bool process_context_magic(uint16_t keycode, keyrecord_t *record)
+bool process_context_magic(uint16_t keycode, keyrecord_t *record, uint16_t special_key_start)
 {
 
     uprintf("Process_context_magic for keycode: %d", keycode);
@@ -377,6 +367,10 @@ bool process_context_magic(uint16_t keycode, keyrecord_t *record)
 
     if (!record->event.pressed)
         return true;
+
+    if (keycode >= special_key_start && keycode < special_key_start + SPECIAL_KEY_COUNT) {
+        keycode = keycode - special_key_start + SPECIAL_KEY_TRIECODE_0;
+    }
 
     // keycode verification and extraction
     if (!process_check(&keycode, record, &mods))

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -6,7 +6,7 @@
 
 //////////////////////////////////////////////////////////////////
 // Public API
-bool process_context_magic(uint16_t keycode, keyrecord_t *record);
+bool process_context_magic(uint16_t keycode, keyrecord_t *record, uint16_t special_key_start);
 
 #if MAGIC_IDLE_TIMEOUT > 0
 void context_magic_task(void);


### PR DESCRIPTION
I created a weak function for mapping magic / special keys from the user's keymap custom keycode to the code expected by the trie (ie 0x01nn).

If the user defines all of their magic / special keys consecutively and defines SEQUENCE_TRANSFORM_SPECIAL_KEY_0 to be the keycode of the first special key, then the default `sequence_transform_map_key_user` function will automatically do the correct mapping. If the user wants to do more pre-processing of incoming key presses, they can do it here by overriding the function in their own code.