### PR TITLE
Fail compile if generated file is a different version than expected.

### DIFF
--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -37,6 +37,8 @@ from string import digits
 from pathlib import Path
 from argparse import ArgumentParser
 
+SEQUENCE_TRANSFORM_GENERATOR_VERSION = "SEQUENCE_TRANSFORM_GENERATOR_VERSION_0_1_0"
+
 parser = ArgumentParser()
 
 parser.add_argument(
@@ -406,6 +408,7 @@ def generate_sequence_transform_data():
 
     sequence_transform_data_h_lines.extend([
         ''
+        f'#define {SEQUENCE_TRANSFORM_GENERATOR_VERSION}',
         f'#define SPECIAL_KEY_TRIECODE_0 {uint16_to_hex(KC_MAGIC_0)}',
         f'#define SEQUENCE_MIN_LENGTH {len(min_sequence)} // "{min_sequence}"',
         f'#define SEQUENCE_MAX_LENGTH {len(max_sequence)} // "{max_sequence}"',

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -13,6 +13,10 @@
 #include "sequence_transform_data.h"
 #include "utils.h"
 
+#ifndef SEQUENCE_TRANSFORM_GENERATOR_VERSION_0_1_0
+    #error "sequence_transform_data.h was generated with an incompatible version of the generator script"
+#endif
+
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
 
 //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It is potentially very bad if the firmware is compiled with a `sequence_transform_data.h` file that uses the an incompatible format.

With this PR, the generated file is tagged with a `#define` that specifies the generator version. Then, `sequence_transform.c` checks that the tag for the version it expects is defined and fails the compile with an error if it is missing.

The version tags are binary, so the compiler looks for an exact match. This means we don't have to do any error prone parsing of version numbers. Since the generator and QMK code should always be updated at exactly the same time, we don't need ranges anyways.