### PR TITLE
Rotating-buffer with struct payload

### DIFF
--- a/keybuffer.c
+++ b/keybuffer.c
@@ -15,7 +15,7 @@
 
 //////////////////////////////////////////////////////////////////
 // Private helper functions
-int get_real_index(key_buffer_t *buf, int index)
+int get_real_index(st_key_buffer_t *buf, int index)
 {
     if (index < 0) {
         index += buf->context_len;
@@ -31,7 +31,7 @@ int get_real_index(key_buffer_t *buf, int index)
     return index;
 }
 
-void resize_context(key_buffer_t *buf, int delta)
+void resize_context(st_key_buffer_t *buf, int delta)
 {
     if (delta < -buf->size || delta > buf->size) {
         uprintf("ABS of buffer resize request (%d) exceeds total available space index (%d)!", delta, buf->size);
@@ -64,7 +64,7 @@ void resize_context(key_buffer_t *buf, int delta)
 // buffer indexing from start or end (with negative index)
 // returns 0 if index is out of bounds
 //
-struct key_action_t* st_key_buffer_get(st_key_buffer_t *buf, int index)
+struct st_key_action_t* st_key_buffer_get(st_key_buffer_t *buf, int index)
 {
     int real_index = get_real_index(buf, index);
     if (real_index < 0) { // index was out of bounds
@@ -76,7 +76,7 @@ struct key_action_t* st_key_buffer_get(st_key_buffer_t *buf, int index)
 void st_key_buffer_reset(st_key_buffer_t *buf)
 {
     buf->context_len = 0;
-    key_buffer_push(buf, KC_SPC);
+    st_key_buffer_push(buf, KC_SPC);
 }
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode)

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -68,8 +68,8 @@ void st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode)
     if (buf->context_len < buf->size) {
         buf->context_len++;
     }
-    if (++buf->cur_pos >= buf->size) {
-        buf->cur_pos = 0;
+    if (++buf->cur_pos >= buf->size) {  // increment cur_pos
+        buf->cur_pos = 0;               // wrap to 0
     }
     buf->data[buf->cur_pos].keypressed = keycode;
     buf->data[buf->cur_pos].action_taken = ST_DEFAULT_KEY_ACTION;
@@ -80,11 +80,11 @@ void st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode)
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num)
 {
-    const int new_context_len = buf->context_len - num;
-    buf->context_len = new_context_len < 0 ? 0 : new_context_len;
-
-    const int new_pos = buf->cur_pos - num;
-    buf->cur_pos = new_pos < 0 ? new_pos + buf->size : new_pos;
+    buf->context_len = MAX(0, buf->context_len - num);
+    buf->cur_pos -= num;
+    if (buf->cur_pos < 0) {
+        buf->cur_pos += buf->size;
+    }
 }
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_print(st_key_buffer_t *buf)

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -11,21 +11,21 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
-typedef struct key_action_t
+typedef struct st_key_action_t
 {
     uint16_t keypressed;
     uint16_t match_offset;
 };
 typedef struct
 {
-    key_action_t   *data;       // array of keycodes
-    uint8_t         size;        // buffer size
-    uint8_t         context_len; // number of current keys in buffer
-    uint8_t         cur_pos;
+    struct st_key_action_t     *data;       // array of keycodes
+    uint8_t                 size;        // buffer size
+    uint8_t                 context_len; // number of current keys in buffer
+    uint8_t                 cur_pos;
 } st_key_buffer_t;
 
-uint16_t    st_key_buffer_get(st_key_buffer_t *buf, int index);
-void        st_key_buffer_reset(st_key_buffer_t *buf);
-void        st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode);
-void        st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num);
-void        st_key_buffer_print(st_key_buffer_t *buf);
+struct st_key_action_t*    st_key_buffer_get(st_key_buffer_t *buf, int index);
+void                    st_key_buffer_reset(st_key_buffer_t *buf);
+void                    st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode);
+void                    st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num);
+void                    st_key_buffer_print(st_key_buffer_t *buf);

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -12,7 +12,7 @@
 // Public API
 
 #define ST_DEFAULT_KEY_ACTION 0xffff
-#define SEQUENCE_TRANSFORM_LOG_GENERAL
+
 typedef struct st_key_action_t
 {
     uint16_t keypressed;

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -11,11 +11,17 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
+typedef struct key_action_t
+{
+    uint16_t keypressed;
+    uint16_t match_offset;
+};
 typedef struct
 {
-    uint16_t    *data;       // array of keycodes
-    uint8_t     size;        // buffer size
-    uint8_t     context_len; // number of current keys in buffer
+    key_action_t   *data;       // array of keycodes
+    uint8_t         size;        // buffer size
+    uint8_t         context_len; // number of current keys in buffer
+    uint8_t         cur_pos;
 } st_key_buffer_t;
 
 uint16_t    st_key_buffer_get(st_key_buffer_t *buf, int index);

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -11,11 +11,13 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
+#define ST_DEFAULT_KEY_ACTION 0xffff
+#define SEQUENCE_TRANSFORM_LOG_GENERAL
 typedef struct st_key_action_t
 {
     uint16_t keypressed;
-    uint16_t match_offset;
-};
+    uint16_t action_taken;
+} st_key_action_t;
 typedef struct
 {
     struct st_key_action_t     *data;       // array of keycodes
@@ -24,7 +26,8 @@ typedef struct
     uint8_t                 cur_pos;
 } st_key_buffer_t;
 
-struct st_key_action_t*    st_key_buffer_get(st_key_buffer_t *buf, int index);
+struct st_key_action_t* st_key_buffer_get(st_key_buffer_t *buf, int index);
+uint16_t                st_key_buffer_get_keycode(st_key_buffer_t *buf, int index);
 void                    st_key_buffer_reset(st_key_buffer_t *buf);
 void                    st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode);
 void                    st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num);

--- a/trie.c
+++ b/trie.c
@@ -22,14 +22,14 @@
 //////////////////////////////////////////////////////////////////
 bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res)
 {
-    return st_find_longest_chain(trie, search, res, 0, 1);
+    return st_find_longest_chain(trie, search, res, 0, 0);
 }
 //////////////////////////////////////////////////////////////////
 void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index)
 {
     // Payload data is bit-backed into 16bits:
     // (N: node type, F: func, B: backspackes, C: completion index)
-    // 0b NNFF FBBB BCCC CCCC  
+    // 0b NNFF FBBB BCCC CCCC
     payload->func_code = (code >> 11) & 7;
     payload->num_backspaces = (code >> 7) & 15;
     payload->completion_len = code & 127;
@@ -87,7 +87,7 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 			return false;
 		code &= TRIE_CODE_MASK;
         // Find child key that matches the search buffer at the current depth
-        const uint16_t cur_key = st_key_buffer_get(search, -depth);
+        const uint16_t cur_key = st_key_buffer_get_keycode(search, depth);
 		for (; code; offset += 2, code = TDATA(offset)) {
             if (code == cur_key) {
                 // 16bit offset to child node is built from next uint16_t
@@ -103,7 +103,7 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 	// Travel down chain until we reach a zero byte, or we no longer match our buffer
 	for (; code; depth++, code = TDATA(++offset)) {
 		if (depth > search->context_len ||
-            code != st_key_buffer_get(search, -depth))
+            code != st_key_buffer_get_keycode(search, depth))
 			return false;
 	}
 	// After a chain, there should be a leaf or branch


### PR DESCRIPTION
To implement the enhanced backspace feature, we need to save a reference to the action taken for each keypress.

In preparation for that, I have enhanced the keybuffer to hold a struct for each keypress.

Additionally, I re-implemented the buffer as a rotating buffer, so now there are no memmoves required. They way our code works, after a word or two to prime the buffer, basically every keypress was triggering a memmove of the full buffer. That is no longer required. Probably not a huge performance gain, but it becomes more significant as the payload gets bigger (we might add more meta-data later) and the buffer gets larger (longer rules).

Finally, I reindexed everything to be more natural. Before, the most recent keypress lived at index -1, which twisted my brain out of me everytime I tried to reason about it. Now, the most recent key press is at index 0 and each increment ohf the index goes one key further back in the history. Since we essentially always want to start at the most recent key and step back into the past. that iteration will now by in the form of `for (i=0; i < buf->context_len; i++) st_key_buffer_get_keycode(buf, i)`

An important note is that the base depth of the trie is now `0` (not `1` or `-1`)