### PR TITLE
Enhanced Backspace

### DIFF
--- a/keybuffer.c
+++ b/keybuffer.c
@@ -94,7 +94,7 @@ void st_key_buffer_print(const st_key_buffer_t *buf)
 {
     uprintf("buffer: |");
     for (int i = -1; i >= -buf->context_len; --i)
-        uprintf("%c  ", st_keycode_to_char(st_key_buffer_get(buf, i)->keypressed));
+        uprintf("%c", st_keycode_to_char(st_key_buffer_get(buf, i)->keypressed));
     uprintf("| (%d)\n", buf->context_len);
 }
 //////////////////////////////////////////////////////////////////

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -94,7 +94,7 @@ void st_key_buffer_print(const st_key_buffer_t *buf)
 {
     uprintf("buffer: |");
     for (int i = -1; i >= -buf->context_len; --i)
-        uprintf("%c", st_keycode_to_char(st_key_buffer_get(buf, i)->keypressed));
+        uprintf("%c  ", st_keycode_to_char(st_key_buffer_get(buf, i)->keypressed));
     uprintf("| (%d)\n", buf->context_len);
 }
 //////////////////////////////////////////////////////////////////

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -12,6 +12,7 @@
 // Public API
 
 #define ST_DEFAULT_KEY_ACTION 0xffff
+#define ST_IGNORE_KEY_ACTION 0x0000
 
 typedef struct
 {

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -31,5 +31,5 @@ static inline void sequence_transform_task(void) {}
 bool st_process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods);
 void st_record_send_key(uint16_t keycode);
 void st_handle_repeat_key(void);
-void st_handle_result(st_trie_t *trie, st_trie_payload_t *res);
+void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res);
 bool st_perform(void);

--- a/trie.c
+++ b/trie.c
@@ -77,18 +77,10 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_mat
         depth--;
         // record this as the new longest match
         longest_match->trie_match_index = offset;
-        longest_match->context_match_len = depth + 1;
+        longest_match->seq_match_len = depth + 1;
         // If bit 14 is also set, there is a child node after the completion string
         if ((code & TRIE_BRANCH_BIT) && st_find_longest_chain(trie, search, longest_match, offset+2, depth+1))
             return true;
-#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
-         // bounds check completion data
-        if (res->completion_index + res->completion_len > trie->completions_size) {
-            uprintf("find_longest_chain() ERROR: trying to read past end of completion data buffer! index: %d, len: %d\n",
-                res->completion_index, res->completion_len);
-            return false;
-        }
-#endif
         // Found a match so return true!
         return true;
 	}

--- a/trie.c
+++ b/trie.c
@@ -32,14 +32,18 @@ bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_se
 //////////////////////////////////////////////////////////////////
 void st_get_payload_from_match_index(st_trie_t *trie, st_trie_payload_t *payload, uint16_t match_index)
 {
-    const uint16_t code = TDATA(match_index);
+    st_get_payload_from_code(payload, TDATA(match_index), TDATA(match_index+1));
+}
+//////////////////////////////////////////////////////////////////
+void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index)
+{
     // Payload data is bit-backed into 16bits:
     // (N: node type, F: func, B: backspackes, C: completion index)
     // 0b NNFF FBBB BCCC CCCC
     payload->func_code = (code >> 11) & 7;
     payload->num_backspaces = (code >> 7) & 15;
     payload->completion_len = code & 127;
-    payload->completion_index = TDATA(match_index+1);
+    payload->completion_index = completion_index;
 }
 
 /**

--- a/trie.c
+++ b/trie.c
@@ -20,20 +20,26 @@
 #define TDATA(L) pgm_read_word(&trie->data[L])
 
 //////////////////////////////////////////////////////////////////
-bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res)
+bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_search_result_t *res)
 {
-    return st_find_longest_chain(trie, search, res, 0, 0);
+
+    if (st_find_longest_chain(trie, search, &res->trie_match, 0, 0)) {
+        st_get_payload_from_match_index(trie, &res->trie_payload, res->trie_match.trie_match_index);
+        return true;
+    }
+    return false;
 }
 //////////////////////////////////////////////////////////////////
-void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index)
+void st_get_payload_from_match_index(st_trie_t *trie, st_trie_payload_t *payload, uint16_t match_index)
 {
+    const uint16_t code = TDATA(match_index);
     // Payload data is bit-backed into 16bits:
     // (N: node type, F: func, B: backspackes, C: completion index)
     // 0b NNFF FBBB BCCC CCCC
     payload->func_code = (code >> 11) & 7;
     payload->num_backspaces = (code >> 7) & 15;
     payload->completion_len = code & 127;
-    payload->completion_index = completion_index;
+    payload->completion_index = TDATA(match_index+1);
 }
 
 /**
@@ -46,7 +52,7 @@ void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_
  * @param depth  current depth in trie
  * @return       true if match found
  */
-bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res, uint16_t offset, uint8_t depth)
+bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_match_t *longest_match, uint16_t offset, uint8_t depth)
 {
 #ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
     if (offset >= trie->data_size) {
@@ -65,12 +71,12 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 	if (code & TRIE_MATCH_BIT) {
         // match nodes are side attachments, so decrease depth
         depth--;
+        // record this as the new longest match
+        longest_match->trie_match_index = offset;
+        longest_match->context_match_len = depth + 1;
         // If bit 14 is also set, there is a child node after the completion string
-        if ((code & TRIE_BRANCH_BIT) && st_find_longest_chain(trie, search, res, offset+2, depth+1))
+        if ((code & TRIE_BRANCH_BIT) && st_find_longest_chain(trie, search, longest_match, offset+2, depth+1))
             return true;
-        // If no better match found deeper, so recordd the payload result!
-        st_get_payload_from_code(res, code, TDATA(offset + 1));
-        res->context_match_len = depth + 1;
 #ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
          // bounds check completion data
         if (res->completion_index + res->completion_len > trie->completions_size) {
@@ -94,7 +100,7 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
                 // 16bit offset to child node is built from next uint16_t
                 const uint16_t child_offset = TDATA(offset+1);
                 // Traverse down child node
-                return st_find_longest_chain(trie, search, res, child_offset, depth+1);
+                return st_find_longest_chain(trie, search, longest_match, child_offset, depth+1);
             }
         }
         // Couldn't go deeper, so return false.
@@ -108,5 +114,5 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 			return false;
 	}
 	// After a chain, there should be a leaf or branch
-	return st_find_longest_chain(trie, search, res, offset+1, depth);
+	return st_find_longest_chain(trie, search, longest_match, offset+1, depth);
 }

--- a/trie.h
+++ b/trie.h
@@ -32,7 +32,7 @@ typedef struct
 typedef struct
 {
     uint16_t            trie_match_index;
-    uint8_t             context_match_len;
+    int                 seq_match_len;
 } st_trie_match_t;
 
 typedef struct

--- a/trie.h
+++ b/trie.h
@@ -27,13 +27,24 @@ typedef struct
     uint8_t     completion_len;     // length of completion string
     uint8_t     num_backspaces;     // number of backspaces to send before the completion string
     uint8_t     func_code;          // special function code
-    uint8_t     context_match_len;
 } st_trie_payload_t;
 
-bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res);
+typedef struct
+{
+    uint16_t            trie_match_index;
+    uint8_t             context_match_len;
+} st_trie_match_t;
+
+typedef struct
+{
+    st_trie_match_t     trie_match;
+    st_trie_payload_t   trie_payload;
+} st_trie_search_result_t;
+
+bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_search_result_t *res);
 
 //////////////////////////////////////////////////////////////////
 // Internal
 
-void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index);
-bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res, uint16_t offset, uint8_t depth);
+void st_get_payload_from_match_index(st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);
+bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_match_t *longest_match, uint16_t offset, uint8_t depth);

--- a/trie.h
+++ b/trie.h
@@ -47,4 +47,5 @@ bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_se
 // Internal
 
 void st_get_payload_from_match_index(st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);
+void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index);
 bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_match_t *longest_match, uint16_t offset, uint8_t depth);


### PR DESCRIPTION
This feature will enhance the handling of backspace so that tapping backspace will undo the entire action of the previous keypress, and leave the buffer in a state where the recent context is identical to before the previous keypress, even if the previous keypress triggered a complicated action.

This draft contains my refactor `st_trie_search_result_t` so that every feature can get the info they need where and how they need it. Specifically, my feature will need to be able to extract an `st_trie_payload_t` using just the trie and an offset to the matching node on the trie. The

Please take a look at it and give feedback.