### PR TITLE
Rule search

### DIFF
--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -524,6 +524,11 @@ def encode_link(link: Dict[str, Any]) -> List[int]:
 ###############################################################################
 def sequence_len(node: Tuple[str, str]) -> int:
     return len(node[0])
+    
+
+###############################################################################
+def transform_len(node: Tuple[str, str]) -> int:
+    return len(node[1])
 
 
 ###############################################################################
@@ -556,6 +561,7 @@ def generate_sequence_transform_data():
 
     min_sequence = min(seq_dict, key=sequence_len)[0]
     max_sequence = max(seq_dict, key=sequence_len)[0]
+    max_transform = max(seq_dict, key=transform_len)[1]
 
     # Build the sequence_transform_data.h file.
     transformations = []
@@ -587,6 +593,7 @@ def generate_sequence_transform_data():
         f'#define SPECIAL_KEY_TRIECODE_0 {uint16_to_hex(KC_MAGIC_0)}',
         f'#define SEQUENCE_MIN_LENGTH {len(min_sequence)} // "{min_sequence}"',
         f'#define SEQUENCE_MAX_LENGTH {len(max_sequence)} // "{max_sequence}"',
+        f'#define TRANSFORM_MAX_LEN {len(max_transform)} // "{max_transform}"',
         f'#define COMPLETION_MAX_LENGTH {max_completion_len}',
         f'#define MAX_BACKSPACES {max_backspaces}',
         f'#define DICTIONARY_SIZE {len(trie_data)}',

--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -38,7 +38,7 @@ from string import digits
 from pathlib import Path
 from argparse import ArgumentParser
 
-ST_GENERATOR_VERSION = "SEQUENCE_TRANSFORM_GENERATOR_VERSION_0_1_0"
+ST_GENERATOR_VERSION = "SEQUENCE_TRANSFORM_GENERATOR_VERSION_2"
 
 GPL2_HEADER_C_LIKE = f'''\
 // Copyright {date.today().year} QMK

--- a/key_stack.c
+++ b/key_stack.c
@@ -10,20 +10,21 @@
 //////////////////////////////////////////////////////////////////////
 void st_key_stack_push(st_key_stack_t *s, uint16_t key)
 {
-    if (s->size < s->capacity)
+    if (s->size < s->capacity) {
         s->buffer[s->size++] = key;
+    }
 }
 //////////////////////////////////////////////////////////////////////
 void st_key_stack_pop(st_key_stack_t *s)
 {
-    if (s->size > 0)
-        s->size--;
+    s->size = st_max(0, s->size - 1);
 }
 //////////////////////////////////////////////////////////////////////
 void st_key_stack_to_str(const st_key_stack_t *s, char *str)
 {
     char *dst = str;
-	for (int i = s->size - 1; i >= 0; --i)
-		*dst++ = st_keycode_to_char(s->buffer[i]);
-	str[s->size] = 0;
+    for (int i = s->size - 1; i >= 0; --i) {
+        *dst++ = st_keycode_to_char(s->buffer[i]);
+    }
+    str[s->size] = 0;
 }

--- a/key_stack.c
+++ b/key_stack.c
@@ -1,0 +1,29 @@
+// Copyright 2024 Guillaume Stordeur <guillaume.stordeur@gmail.com>
+// Copyright 2024 Matt Skalecki <ikcelaks@gmail.com>
+// Copyright 2024 QKekos <q.kekos.q@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "key_stack.h"
+#include "utils.h"
+
+//////////////////////////////////////////////////////////////////////
+void st_key_stack_push(st_key_stack_t *s, uint16_t key)
+{
+    if (s->size < s->capacity)
+        s->buffer[s->size++] = key;
+}
+//////////////////////////////////////////////////////////////////////
+void st_key_stack_pop(st_key_stack_t *s)
+{
+    if (s->size > 0)
+        s->size--;
+}
+//////////////////////////////////////////////////////////////////////
+void st_key_stack_to_str(const st_key_stack_t *s, char *str)
+{
+    char *dst = str;
+	for (int i = s->size - 1; i >= 0; --i)
+		*dst++ = st_keycode_to_char(s->buffer[i]);
+	str[s->size] = 0;
+}

--- a/key_stack.h
+++ b/key_stack.h
@@ -7,9 +7,9 @@
 
 typedef struct
 {
-	uint16_t    *buffer;
-    uint8_t     capacity;
-	uint8_t     size;	
+    uint16_t    *buffer;
+    int         capacity;
+    int         size;	
 } st_key_stack_t;
 
 void st_key_stack_push(st_key_stack_t *s, uint16_t key);

--- a/key_stack.h
+++ b/key_stack.h
@@ -1,0 +1,17 @@
+// Copyright 2024 Guillaume Stordeur <guillaume.stordeur@gmail.com>
+// Copyright 2024 Matt Skalecki <ikcelaks@gmail.com>
+// Copyright 2024 QKekos <q.kekos.q@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+typedef struct
+{
+	uint16_t    *buffer;
+    uint8_t     capacity;
+	uint8_t     size;	
+} st_key_stack_t;
+
+void st_key_stack_push(st_key_stack_t *s, uint16_t key);
+void st_key_stack_pop(st_key_stack_t *s);
+void st_key_stack_to_str(const st_key_stack_t *s, char *str);

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -104,9 +104,7 @@ void st_key_buffer_to_str(const st_key_buffer_t *buf, char* output_string, uint8
 
     for (; i < len; i += 1) {
         uint16_t current_keycode = st_key_buffer_get_keycode(buf, len - i - 1);
-        char current_char = st_keycode_to_char(current_keycode);
-
-        output_string[i] = current_char == ' ' ? ':' : current_char;
+        output_string[i] = st_keycode_to_char(current_keycode);
     }
 
     output_string[i] = '\0';

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -44,11 +44,11 @@ st_key_action_t *st_key_buffer_get(const st_key_buffer_t *buf, int index)
 #endif
         return NULL;
     }
-    return &buf->data[
-        buf->cur_pos >= index
-            ? buf->cur_pos - index
-            : buf->size + index - buf->cur_pos //wrap around
-    ];
+    int buf_index = buf->cur_pos - index;
+    if (buf_index < 0) {
+        buf_index += buf->size;
+    }
+    return &buf->data[buf_index];
 }
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_reset(st_key_buffer_t *buf)

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -27,13 +27,13 @@
 //   st_key_buffer_get(buf, -2) -> b
 //   st_key_buffer_get(buf, -3) -> c
 // returns KC_NO if index is out of bounds
-uint16_t st_key_buffer_get_keycode(st_key_buffer_t *buf, int index)
+uint16_t st_key_buffer_get_keycode(const st_key_buffer_t *buf, int index)
 {
     const st_key_action_t *keyaction = st_key_buffer_get(buf, index);
     return (keyaction ? keyaction->keypressed : KC_NO);
 }
 //////////////////////////////////////////////////////////////////
-st_key_action_t *st_key_buffer_get(st_key_buffer_t *buf, int index)
+st_key_action_t *st_key_buffer_get(const st_key_buffer_t *buf, int index)
 {
     if (index < 0) {
         index += buf->context_len;
@@ -90,7 +90,7 @@ void st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num)
     }
 }
 //////////////////////////////////////////////////////////////////
-void st_key_buffer_print(st_key_buffer_t *buf)
+void st_key_buffer_print(const st_key_buffer_t *buf)
 {
     uprintf("buffer: |");
     for (int i = -1; i >= -buf->context_len; --i)
@@ -98,7 +98,7 @@ void st_key_buffer_print(st_key_buffer_t *buf)
     uprintf("| (%d)\n", buf->context_len);
 }
 //////////////////////////////////////////////////////////////////
-void st_key_buffer_to_str(st_key_buffer_t *buf, char* output_string, uint8_t len)
+void st_key_buffer_to_str(const st_key_buffer_t *buf, char* output_string, uint8_t len)
 {
     int i = 0;
 

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -92,10 +92,12 @@ void st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num)
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_print(const st_key_buffer_t *buf)
 {
+#ifdef CONSOLE_ENABLE
     uprintf("buffer: |");
     for (int i = -1; i >= -buf->context_len; --i)
         uprintf("%c", st_keycode_to_char(st_key_buffer_get(buf, i)->keypressed));
     uprintf("| (%d)\n", buf->context_len);
+#endif
 }
 //////////////////////////////////////////////////////////////////
 void st_key_buffer_to_str(const st_key_buffer_t *buf, char* output_string, uint8_t len)

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -20,12 +20,10 @@ typedef struct
 } st_key_action_t;
 typedef struct
 {
-    st_key_action_t     *data;       // array of keycodes
-    // TODO rename to capacity
-    int             size;        // buffer size
-    // TODO rename to size
-    int             context_len; // number of current keys in buffer
-    int             cur_pos;
+    st_key_action_t * const data;        // array of keycodes
+    const int               size;        // buffer size (TODO: rename to capacity)
+    int                     context_len; // number of current keys in buffer (TODO: rename to size)
+    int                     cur_pos;     // current head for circular access
 } st_key_buffer_t;
 
 st_key_action_t         *st_key_buffer_get(const st_key_buffer_t *buf, int index);

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -28,10 +28,10 @@ typedef struct
     uint8_t             cur_pos;
 } st_key_buffer_t;
 
-st_key_action_t         *st_key_buffer_get(st_key_buffer_t *buf, int index);
-uint16_t                st_key_buffer_get_keycode(st_key_buffer_t *buf, int index);
+st_key_action_t         *st_key_buffer_get(const st_key_buffer_t *buf, int index);
+uint16_t                st_key_buffer_get_keycode(const st_key_buffer_t *buf, int index);
 void                    st_key_buffer_reset(st_key_buffer_t *buf);
 void                    st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode);
 void                    st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num);
-void                    st_key_buffer_print(st_key_buffer_t *buf);
-void                    st_key_buffer_to_str(st_key_buffer_t *buf, char* output_string, uint8_t len);
+void                    st_key_buffer_print(const st_key_buffer_t *buf);
+void                    st_key_buffer_to_str(const st_key_buffer_t *buf, char *output_string, uint8_t len);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -13,7 +13,7 @@
 #include "sequence_transform_data.h"
 #include "utils.h"
 
-#ifndef SEQUENCE_TRANSFORM_GENERATOR_VERSION_0_1_0
+#ifndef SEQUENCE_TRANSFORM_GENERATOR_VERSION_2
 #  error "sequence_transform_data.h was generated with an incompatible version of the generator script"
 #endif
 

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -263,8 +263,8 @@ __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
-    char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
-    char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
+    char sequence_str[SEQUENCE_MAX_LENGTH * 4 + 1] = {0};
+    char transform_str[TRANSFORM_MAX_LEN * 4 + 1] = {0};
     static int search_len_start = 1;
     // Start search from last space
     if (PREV_KEY == KC_SPACE) {

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -18,7 +18,7 @@
 #endif
 
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
-#define PREV_KEY st_key_buffer_get_keycode(&key_buffer, 0)
+#define KEY_AT(i) st_key_buffer_get_keycode(&key_buffer, (i))
 
 //////////////////////////////////////////////////////////////////
 // Key history buffer
@@ -265,33 +265,27 @@ void st_find_missed_rule(void)
 {
     char sequence_str[SEQUENCE_MAX_LENGTH * 4 + 1] = {0};
     char transform_str[TRANSFORM_MAX_LEN * 4 + 1] = {0};
-    static int search_len_start = 1;
-    // Start search from last space
-    if (PREV_KEY == KC_SPACE) {
-        search_len_start = key_buffer.context_len;
+    static int search_len_from_space = 0;
+    // find buffer index for last space
+    int last_space_index = 0;
+    while (last_space_index < key_buffer.context_len &&
+           KEY_AT(last_space_index) != KC_SPACE) {
+        ++last_space_index;
+    }
+    if (last_space_index == 0) {
+        search_len_from_space = 0;
         return;
     }
-    // Buffer starts rolling when full, so dec search search_len_start.
-    if (key_buffer.context_len == key_buffer.size) {
-        search_len_start = st_max(1, search_len_start - 1);
-    } else {
-        // Don't let search_len_start get ahead of context len.
-        // (this handles backspace and buffer reset)
-        search_len_start = st_min(search_len_start, key_buffer.context_len - 1);
-    }
+    const int search_len_start = key_buffer.context_len - last_space_index
+        + search_len_from_space;
     st_trie_rule_t result;
     result.sequence = sequence_str;
     result.transform = transform_str;
-    int t = timer_read32();
-    const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
-#ifdef SEQUENCE_TRANSFORM_LOG_GENERAL
-    t = timer_elapsed32(t);
-    uprintf("st_trie_get_rule time: %d\n", t);
-#endif
-    if (next_start != search_len_start) {
+    const int len_offset = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
+    if (len_offset) {
         sequence_transform_on_missed_rule_user(&result);
         // Next time, start searching from after completion
-        search_len_start = next_start;
+        search_len_from_space += len_offset;
     }
 }
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -237,7 +237,7 @@ void log_rule(st_trie_t *trie, st_trie_payload_t *res) {
     uprintf("\n");
 }
 //////////////////////////////////////////////////////////////////////
-__attribute__((weak)) void st_on_missed_rule(const st_trie_rule_t *rule)
+__attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_rule_t *rule)
 {
     uprintf("Missed rule! %s -> %s\n", rule->rule, rule->completion);
 }
@@ -260,7 +260,7 @@ void st_find_missed_rule(void)
     result.completion = completion_str;
     const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);
     if (next_start != search_len_start) {
-        st_on_missed_rule(&result);
+        sequence_transform_on_missed_rule_user(&result);
         // Next time, start searching from after completion
         search_len_start = next_start;
     }

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -247,12 +247,12 @@ void log_rule(st_trie_t *trie, st_trie_payload_t *res) {
 //////////////////////////////////////////////////////////////////////
 __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_rule_t *rule)
 {
-    uprintf("Missed rule! %s -> %s\n", rule->rule, rule->completion);
+    uprintf("Missed rule! %s -> %s\n", rule->sequence, rule->completion);
 }
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
-    char rule_str[SEQUENCE_MAX_LENGTH + 1];
+    char sequence_str[SEQUENCE_MAX_LENGTH + 1];
     char completion_str[COMPLETION_MAX_LENGTH + 1];
     static int search_len_start = 1;
     const uint16_t keycode = st_key_buffer_get_keycode(&key_buffer, 0);
@@ -270,7 +270,7 @@ void st_find_missed_rule(void)
         search_len_start = st_min(search_len_start, key_buffer.context_len - 1);
     }
     st_trie_rule_t result;
-    result.rule = rule_str;
+    result.sequence = sequence_str;
     result.completion = completion_str;
     int t = timer_read32();
     const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -263,8 +263,8 @@ __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
-    char sequence_str[SEQUENCE_MAX_LENGTH * 4 + 1] = {0};
-    char transform_str[TRANSFORM_MAX_LEN * 4 + 1] = {0};
+    char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
+    char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
     static int search_len_from_space = 0;
     // find buffer index for last space
     int last_space_index = 0;

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -246,7 +246,7 @@ void st_find_missed_rule(void)
 {
     char rule_str[SEQUENCE_MAX_LENGTH + 1];
     char completion_str[COMPLETION_MAX_LENGTH + 1];
-    static uint8_t search_len_start = 1;
+    static int search_len_start = 1;
     // Buffer starts rolling when full, so dec search search_len_start.
     if (key_buffer.context_len == key_buffer.size) {
         search_len_start = st_max(1, search_len_start - 1);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -266,7 +266,12 @@ void st_find_missed_rule(void)
     st_trie_rule_t result;
     result.rule = rule_str;
     result.completion = completion_str;
-    const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);
+    int t = timer_read32();
+    const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
+#ifdef SEQUENCE_TRANSFORM_LOG_GENERAL
+    t = timer_elapsed32(t);
+    uprintf("st_trie_get_rule time: %d\n", t);
+#endif
     if (next_start != search_len_start) {
         sequence_transform_on_missed_rule_user(&result);
         // Next time, start searching from after completion

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -237,6 +237,11 @@ void log_rule(st_trie_t *trie, st_trie_payload_t *res) {
     uprintf("\n");
 }
 //////////////////////////////////////////////////////////////////////
+__attribute__((weak)) void st_on_missed_rule(const st_trie_rule_t *rule)
+{
+    uprintf("Missed rule! %s -> %s\n", rule->rule, rule->completion);
+}
+//////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
     char rule_str[SEQUENCE_MAX_LENGTH + 1];
@@ -255,7 +260,7 @@ void st_find_missed_rule(void)
     result.completion = completion_str;
     const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);
     if (next_start != search_len_start) {
-        uprintf("Missed rule: %s -> %s (new start: %d)\n", rule_str, completion_str, next_start);
+        st_on_missed_rule(&result);
         // Next time, start searching from after completion
         search_len_start = next_start;
     }

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -255,6 +255,12 @@ void st_find_missed_rule(void)
     char rule_str[SEQUENCE_MAX_LENGTH + 1];
     char completion_str[COMPLETION_MAX_LENGTH + 1];
     static int search_len_start = 1;
+    const uint16_t keycode = st_key_buffer_get_keycode(&key_buffer, 0);
+    // Start search from last space
+    if (keycode == KC_SPACE) {
+        search_len_start = key_buffer.context_len;
+        return;
+    }
     // Buffer starts rolling when full, so dec search search_len_start.
     if (key_buffer.context_len == key_buffer.size) {
         search_len_start = st_max(1, search_len_start - 1);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -217,14 +217,14 @@ void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
     char context_string[SEQUENCE_MAX_LENGTH + 1];
     st_key_buffer_to_str(&key_buffer, context_string, res->trie_match.seq_match_len);
 
-    char rule_trigger_char = context_string[res->trie_match.seq_match_len - 1];
-    context_string[res->trie_match.seq_match_len - 1] = '\0';
+    const int match_len = res->trie_match.seq_match_len - 1;
+    char rule_trigger_char = context_string[match_len];
+    context_string[match_len] = '\0';
 
-    // TODO remove 'R' hardcode
-    bool is_repeat = rule_trigger_char == 'R' && strlen(context_string) == 0;
+    const bool is_repeat = KEY_AT(0) == SPECIAL_KEY_TRIECODE_0+1 && match_len == 0;
 
     if (is_repeat) {
-        uint16_t last_key = st_key_buffer_get_keycode(&key_buffer, 1);
+        uint16_t last_key = KEY_AT(1);
 
         context_string[0] = st_keycode_to_char(last_key);
         context_string[1] = '\0';
@@ -323,7 +323,7 @@ void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
         case 3:  // disable auto-wordbreak
             ends_with_wordbreak = false;
     }
-    if (ends_with_wordbreak && st_key_buffer_get_keycode(&key_buffer, 0) != KC_SPC) {
+    if (ends_with_wordbreak && KEY_AT(0) != KC_SPC) {
         // If the last key in an action outputs a wordbreak character, we need to mark in the buffer
         // that we are at a word break. Currently, we must hack this by appending a fake KC_SPC to the buffer.
         // We mark the action as ST_IGNORE_KEY_ACTION to designate that this is a fake key press with

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -476,7 +476,8 @@ bool process_sequence_transform(uint16_t keycode, keyrecord_t *record, uint16_t 
     mods |= get_oneshot_mods();
 #endif
 #ifdef SEQUENCE_TRANSFORM_LOG_GENERAL
-    uprintf("pst keycode: 0x%04X\n", keycode);
+    uprintf("pst keycode: 0x%04X, mods: 0x%02X, pressed: %d\n",
+            keycode, mods, record->event.pressed);
 #endif
     // If this is one of the special keycodes, convert to our internal trie code
     if (keycode >= special_key_start && keycode < special_key_start + SEQUENCE_TRANSFORM_COUNT) {

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -18,6 +18,7 @@
 #endif
 
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
+#define PREV_KEY st_key_buffer_get_keycode(&key_buffer, 0)
 
 //////////////////////////////////////////////////////////////////
 // Key history buffer
@@ -257,17 +258,16 @@ void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
 //////////////////////////////////////////////////////////////////////
 __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_rule_t *rule)
 {
-    uprintf("Missed rule! %s -> %s\n", rule->sequence, rule->completion);
+    uprintf("Missed rule! %s -> %s\n", rule->sequence, rule->transform);
 }
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
-    char sequence_str[SEQUENCE_MAX_LENGTH + 1];
-    char completion_str[COMPLETION_MAX_LENGTH + 1];
+    char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
+    char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
     static int search_len_start = 1;
-    const uint16_t keycode = st_key_buffer_get_keycode(&key_buffer, 0);
     // Start search from last space
-    if (keycode == KC_SPACE) {
+    if (PREV_KEY == KC_SPACE) {
         search_len_start = key_buffer.context_len;
         return;
     }
@@ -281,7 +281,7 @@ void st_find_missed_rule(void)
     }
     st_trie_rule_t result;
     result.sequence = sequence_str;
-    result.completion = completion_str;
+    result.transform = transform_str;
     int t = timer_read32();
     const uint8_t next_start = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
 #ifdef SEQUENCE_TRANSFORM_LOG_GENERAL

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -273,19 +273,24 @@ void st_find_missed_rule(void)
         ++last_space_index;
     }
     if (last_space_index == 0) {
+        //uprintf("space at top, resetting search_len_from_space\n");
         search_len_from_space = 0;
         return;
     }
-    const int search_len_start = key_buffer.context_len - last_space_index
-        + search_len_from_space;
+    //uprintf("last_space_index: %d, search_len_from_space: %d\n",
+    //        last_space_index, search_len_from_space);
+    const int len_to_last_space = key_buffer.context_len - last_space_index;
+    const int search_len_start = st_clamp(len_to_last_space + search_len_from_space,
+                                          1,
+                                          key_buffer.context_len - 1);
     st_trie_rule_t result;
     result.sequence = sequence_str;
     result.transform = transform_str;
-    const int len_offset = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
-    if (len_offset) {
+    const int new_len = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);    
+    if (new_len != search_len_start) {
         sequence_transform_on_missed_rule_user(&result);
         // Next time, start searching from after completion
-        search_len_from_space += len_offset;
+        search_len_from_space = new_len - len_to_last_space;
     }
 }
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -213,6 +213,7 @@ void st_handle_repeat_key()
 }
 ///////////////////////////////////////////////////////////////////////////////
 void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
+#if defined(RECORD_RULE_USAGE) && defined(CONSOLE_ENABLE)
     // Main body
     char context_string[SEQUENCE_MAX_LENGTH + 1];
     st_key_buffer_to_str(&key_buffer, context_string, res->trie_match.seq_match_len);
@@ -254,15 +255,19 @@ void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
 
     // Terminator
     uprintf("\n");
+#endif
 }
 //////////////////////////////////////////////////////////////////////
 __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_rule_t *rule)
 {
+#ifdef CONSOLE_ENABLE
     uprintf("Missed rule! %s -> %s\n", rule->sequence, rule->transform);
+#endif
 }
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
+#ifdef SEQUENCE_TRANSFORM_MISSED_RULES
     char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
     char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
     static int search_len_from_space = 0;
@@ -292,6 +297,7 @@ void st_find_missed_rule(void)
         // Next time, start searching from after completion
         search_len_from_space = new_len - len_to_last_space;
     }
+#endif
 }
 //////////////////////////////////////////////////////////////////////////////////////////
 void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
@@ -299,9 +305,9 @@ void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
     uprintf("completion search res: index: %d, len: %d, bspaces: %d, func: %d\n",
             res->trie_payload.completion_index, res->trie_payload.completion_len, res->trie_payload.num_backspaces, res->trie_payload.func_code);
 #endif
-#if defined(RECORD_RULE_USAGE) && defined(CONSOLE_ENABLE)
+
     log_rule(trie, res);
-#endif
+
     // Most recent key in the buffer triggered a match action, record it in the buffer
     st_key_buffer_get(&key_buffer, 0)->action_taken = res->trie_match.trie_match_index;
     // Send backspaces
@@ -530,9 +536,7 @@ bool process_sequence_transform(uint16_t keycode, keyrecord_t *record, uint16_t 
         // tell QMK to not process this key
         return false;
     } else {
-#ifdef SEQUENCE_TRANSFORM_MISSED_RULES
         st_find_missed_rule();
-#endif
     }
     return true;
 }

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -242,9 +242,14 @@ void st_find_missed_rule(void)
     char rule_str[SEQUENCE_MAX_LENGTH + 1];
     char completion_str[COMPLETION_MAX_LENGTH + 1];
     static uint8_t search_len_start = 1;
-    // If key buffer was reset, reset search_len_start
-    if (search_len_start > key_buffer.context_len)
-        search_len_start = 1;    
+    // Buffer starts rolling when full, so dec search search_len_start.
+    if (key_buffer.context_len == key_buffer.size) {
+        search_len_start = st_max(1, search_len_start - 1);
+    } else {
+        // Don't let search_len_start get ahead of context len.
+        // (this handles backspace and buffer reset)
+        search_len_start = st_min(search_len_start, key_buffer.context_len - 1);
+    }
     st_trie_rule_t result;
     result.rule = rule_str;
     result.completion = completion_str;

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include "action.h"
 #include "keybuffer.h"
+#include "key_stack.h"
 #include "trie.h"
 
 //////////////////////////////////////////////////////////////////
@@ -33,3 +34,4 @@ void st_record_send_key(uint16_t keycode);
 void st_handle_repeat_key(void);
 void st_handle_result(st_trie_t *trie, st_trie_payload_t *res);
 bool st_perform(void);
+void st_find_missed_rule(void);

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -19,6 +19,7 @@
 // Public API
 
 bool process_sequence_transform(uint16_t keycode, keyrecord_t *record, uint16_t special_key_start);
+void sequence_transform_on_missed_rule_user(const st_trie_rule_t *rule);
 
 #if SEQUENCE_TRANSFORM_IDLE_TIMEOUT > 0
 void sequence_transform_task(void);
@@ -35,4 +36,3 @@ void st_handle_repeat_key(void);
 void st_handle_result(st_trie_t *trie, st_trie_payload_t *res);
 bool st_perform(void);
 void st_find_missed_rule(void);
-void st_on_missed_rule(const st_trie_rule_t *rule);

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -35,3 +35,4 @@ void st_handle_repeat_key(void);
 void st_handle_result(st_trie_t *trie, st_trie_payload_t *res);
 bool st_perform(void);
 void st_find_missed_rule(void);
+void st_on_missed_rule(const st_trie_rule_t *rule);

--- a/trie.c
+++ b/trie.c
@@ -131,6 +131,8 @@ int st_trie_get_rule(st_trie_t              *trie,
         // Each skip level allows for a magic key or deleted char.
         for (search.skip_levels = 1; search.skip_levels <= max_skip_levels; ++search.skip_levels) {
             search.search_len = len + search.skip_levels;
+            if (search.search_len > key_buffer->context_len)
+                break;
             trie->key_stack->size = 0;
             st_find_rule(&search, 0);
             if (search.max_completed_chars) {

--- a/trie.c
+++ b/trie.c
@@ -115,102 +115,106 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 	return st_find_longest_chain(trie, search, res, offset+1, depth);
 }
 //////////////////////////////////////////////////////////////////////
-uint8_t st_trie_get_rule(st_trie_t             *trie,
-                         const st_key_buffer_t *key_buffer,
-                         uint8_t               search_len_start,
-                         st_trie_rule_t        *res)
+int st_trie_get_rule(st_trie_t              *trie,
+                     const st_key_buffer_t  *key_buffer,
+                     int                    search_len_start,
+                     st_trie_rule_t         *res)
 {
-	st_trie_search_t search;
+    st_trie_search_t search;
     search.trie = trie;
     search.key_buffer = key_buffer;
     search.result = res;
     search.max_completed_chars = 0;    
-    const uint8_t max_skip_levels = 1 + trie->max_backspaces;
-	for (uint8_t len = search_len_start; len < key_buffer->context_len; ++len) {
-		// For every base search_len, increase skip_levels until we find a match.
-		// Each skip level allows for a magic key or deleted char.
-		for (search.skip_levels = 1; search.skip_levels <= max_skip_levels; ++search.skip_levels) {
-			search.search_len = len + search.skip_levels;
-			trie->key_stack->size = 0;
-			st_find_rule(&search, 0);
-			if (search.max_completed_chars) {
+    const int max_skip_levels = 1 + trie->max_backspaces;
+    for (int len = search_len_start; len < key_buffer->context_len; ++len) {
+        // For every base search_len, increase skip_levels until we find a match.
+        // Each skip level allows for a magic key or deleted char.
+        for (search.skip_levels = 1; search.skip_levels <= max_skip_levels; ++search.skip_levels) {
+            search.search_len = len + search.skip_levels;
+            trie->key_stack->size = 0;
+            st_find_rule(&search, 0);
+            if (search.max_completed_chars) {
                 return len + res->payload.completion_len;
-			}
-		}
-	}
-	return search_len_start;
+            }
+        }
+    }
+    return search_len_start;
 }
 //////////////////////////////////////////////////////////////////////
 bool st_find_rule(st_trie_search_t *search, uint16_t offset)
 {
-    // Simulate future buffer keys by offsetting buffer access
-#define OFFSET_BUFFER_VAL st_key_buffer_get_keycode(key_buffer, (int)key_stack->size - (int)search->search_len)
+// Simulate future buffer keys by offsetting buffer access
+#define OFFSET_BUFFER_VAL st_key_buffer_get_keycode(key_buffer, key_stack->size - search->search_len)
     st_trie_t *trie = search->trie;
     const st_key_buffer_t *key_buffer = search->key_buffer;
     st_key_stack_t *key_stack = trie->key_stack;    
     uint16_t code = TDATA(offset);
-	// Match Node if bit 15 is set
-	if (code & TRIE_MATCH_BIT) {
-		// If bit 14 is also set, there's a child node after the completion string
-		if ((code & TRIE_BRANCH_BIT) && st_find_rule(search, offset+2))
-			return true;
+    // Match Node if bit 15 is set
+    if (code & TRIE_MATCH_BIT) {
+        // If bit 14 is also set, there's a child node after the completion string
+        if ((code & TRIE_BRANCH_BIT) && st_find_rule(search, offset + 2)) {
+            return true;
+        }
         // If no better match found deeper,
         // inspect this payload to see if the rule would match
         st_trie_payload_t payload;
         st_get_payload_from_code(&payload, code, TDATA(offset + 1));
         // Make sure skip_levels matches 1 magic key + backspaces,
         // and that removing those wouldn't leave us with an empty context
-        const uint8_t skips = 1 + payload.num_backspaces;
-        if (search->skip_levels != skips || key_stack->size <= skips)
+        const int skips = 1 + payload.num_backspaces;
+        if (search->skip_levels != skips || key_stack->size <= skips) {
             return false;
+        }
         st_check_rule_match(&payload, search);
-		// Found a match so return true!
-		return true;
-	}
-	// BRANCH node if bit 14 is set
-	if (code & TRIE_BRANCH_BIT) {
-		if (key_stack->size >= search->search_len)
-			return false;
-		code &= TRIE_CODE_MASK;
-		bool res = false;
-		const bool check = key_stack->size >= search->skip_levels;
-        const uint16_t cur_key = check ? OFFSET_BUFFER_VAL : 0;
-		// find child that matches our current buffer location
-		// (if this is a skip level, we go down all children)
-		for (; code; offset += 2, code = TDATA(offset)) {
-			if (!check || cur_key == code) {
-				// Get 16bit offset to child node
-				const int child_offset = TDATA(offset + 1);
-				// Traverse down child node
-				st_key_stack_push(key_stack, code);
-				res = st_find_rule(search, child_offset) || res;
-				st_key_stack_pop(key_stack);
-				if (check)
-					return res;
-			}
-		}
-		return res;
-	}
-	// No high bits set, so this is a chain node
-	// Travel down chain until we reach a zero code, or we no longer match our buffer
-	const int prev_stack_size = key_stack->size;
-	for (; code; code = TDATA(++offset)) {
+        // Found a match so return true!
+        return true;
+    }
+    // BRANCH node if bit 14 is set
+    if (code & TRIE_BRANCH_BIT) {
         if (key_stack->size >= search->search_len) {
-			key_stack->size = prev_stack_size;
-			return false;
-		}
+            return false;
+        }
+        code &= TRIE_CODE_MASK;
+        bool res = false;
+        const bool check = key_stack->size >= search->skip_levels;
+        const uint16_t cur_key = check ? OFFSET_BUFFER_VAL : 0;
+        // find child that matches our current buffer location
+        // (if this is a skip level, we go down all children)
+        for (; code; offset += 2, code = TDATA(offset)) {
+            if (!check || cur_key == code) {
+                // Get 16bit offset to child node
+                const uint16_t child_offset = TDATA(offset + 1);
+                // Traverse down child node
+                st_key_stack_push(key_stack, code);
+                res = st_find_rule(search, child_offset) || res;
+                st_key_stack_pop(key_stack);
+                if (check) {
+                    return res;
+                }
+            }
+        }
+        return res;
+    }
+    // No high bits set, so this is a chain node
+    // Travel down chain until we reach a zero code, or we no longer match our buffer
+    const int prev_stack_size = key_stack->size;
+    for (; code; code = TDATA(++offset)) {
+        if (key_stack->size >= search->search_len) {
+            key_stack->size = prev_stack_size;
+            return false;
+        }
         const bool check = key_stack->size >= search->skip_levels;
         const uint16_t cur_key = check ? OFFSET_BUFFER_VAL : 0;
         if (check && cur_key != code) {
-			key_stack->size = prev_stack_size;
-			return false;
-		}
-		st_key_stack_push(key_stack, code);		
-	}
-	// After a chain, there should be a leaf or branch
-	const bool res = st_find_rule(search, offset+1);
-	key_stack->size = prev_stack_size;
-	return res;
+            key_stack->size = prev_stack_size;
+            return false;
+        }
+        st_key_stack_push(key_stack, code);
+    }
+    // After a chain, there should be a leaf or branch
+    const bool res = st_find_rule(search, offset+1);
+    key_stack->size = prev_stack_size;
+    return res;
 }
 //////////////////////////////////////////////////////////////////////
 void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search)
@@ -221,16 +225,17 @@ void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
     // Early return if:
     // 1. potential completed len is smaller than our current best
     // 2. potential completed len overflows search buffer
-    uint8_t clen = search->search_len - search->skip_levels;
-    const uint8_t clen_end = clen + payload->completion_len;
+    int clen = search->search_len - search->skip_levels;
+    const int clen_end = clen + payload->completion_len;
     if (clen_end < search->max_completed_chars ||
-        clen_end > search->key_buffer->context_len)
+        clen_end > search->key_buffer->context_len) {
         return;
+    }
     //uprintf("  testing completion: ");
     // Check if completed string matches what comes next in our search buffer
-    const uint16_t completion_end = payload->completion_index + payload->completion_len;
+    const int completion_end = payload->completion_index + payload->completion_len;
     char *completion_str = res->completion;
-    for (uint16_t i = payload->completion_index; i < completion_end; ++i, ++clen) {
+    for (int i = payload->completion_index; i < completion_end; ++i, ++clen) {
         const char ascii_code = CDATA(i);
         // Save to ascii completion string at the same time
         *completion_str++ = ascii_code;       

--- a/trie.c
+++ b/trie.c
@@ -78,12 +78,12 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_mat
 	if (code & TRIE_MATCH_BIT) {
         // match nodes are side attachments, so decrease depth
         depth--;
-        // record this as the new longest match
-        longest_match->trie_match_index = offset;
-        longest_match->seq_match_len = depth + 1;
         // If bit 14 is also set, there is a child node after the completion string
         if ((code & TRIE_BRANCH_BIT) && st_find_longest_chain(trie, search, longest_match, offset+2, depth+1))
             return true;
+        // this is the longest match, so record it
+        longest_match->trie_match_index = offset;
+        longest_match->seq_match_len = depth + 1;
         // Found a match so return true!
         return true;
 	}

--- a/trie.c
+++ b/trie.c
@@ -134,14 +134,15 @@ int st_trie_get_rule(st_trie_t              *trie,
             search.search_len = len + search.skip_levels;
             if (search.search_len > key_buffer->context_len)
                 break;
+            //uprintf("  searching from len %d, skips: %d\n", len, search.skip_levels);
             trie->key_stack->size = 0;
             st_find_rule(&search, 0);
             if (search.max_transform_len) {
-                return len + res->payload.completion_len;
+                return res->payload.completion_len;
             }
         }
     }
-    return search_len_start;
+    return 0;
 }
 //////////////////////////////////////////////////////////////////////
 bool st_find_rule(st_trie_search_t *search, uint16_t offset)

--- a/trie.c
+++ b/trie.c
@@ -138,11 +138,11 @@ int st_trie_get_rule(st_trie_t              *trie,
             trie->key_stack->size = 0;
             st_find_rule(&search, 0);
             if (search.max_transform_len) {
-                return res->payload.completion_len;
+                return len + res->payload.completion_len;
             }
         }
     }
-    return 0;
+    return search_len_start;
 }
 //////////////////////////////////////////////////////////////////////
 bool st_find_rule(st_trie_search_t *search, uint16_t offset)

--- a/trie.c
+++ b/trie.c
@@ -255,10 +255,20 @@ void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
     char *transform = res->transform;
     for (int i = trie->key_stack->size - 1; i >= 0; --i) {
         const uint16_t keycode = trie->key_stack->buffer[i];
-        const char c = st_keycode_to_char(keycode);
-        *seq++ = c;
+        const char *token = st_get_seq_token_symbol(keycode);
+        char c;
+        if (token) {
+            seq = st_strcpy(seq, token);
+        } else {
+            c = st_keycode_to_char(keycode);
+            *seq++ = c;
+        }
         if (i >= 1 + payload->num_backspaces) {
-            *transform++ = c;
+            if (token) {
+                transform = st_strcpy(transform, token);
+            } else {
+                *transform++ = c;
+            }            
         }
     }
     *seq = 0;

--- a/trie.c
+++ b/trie.c
@@ -14,6 +14,7 @@
 #include "key_stack.h"
 #include "trie.h"
 #include "utils.h"
+#include "keycodes.h"
 #include "print.h"
 
 #define TRIE_MATCH_BIT      0x8000
@@ -256,20 +257,11 @@ void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
     char *transform = res->transform;
     for (int i = trie->key_stack->size - 1; i >= 0; --i) {
         const uint16_t keycode = trie->key_stack->buffer[i];
-        const char *token = st_get_seq_token_symbol(keycode);
-        char c;
-        if (token) {
-            seq = st_strcpy(seq, token);
-        } else {
-            c = st_keycode_to_char(keycode);
-            *seq++ = c;
-        }
-        if (i >= 1 + payload->num_backspaces) {
-            if (token) {
-                transform = st_strcpy(transform, token);
-            } else {
-                *transform++ = c;
-            }            
+        const char c = st_keycode_to_char(keycode);
+        *seq++ = c;
+        if (i >= 1 + payload->num_backspaces &&
+            !(i == trie->key_stack->size - 1 && keycode == KC_SPACE)) {
+            *transform++ = c;
         }
     }
     *seq = 0;

--- a/trie.c
+++ b/trie.c
@@ -247,14 +247,24 @@ void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
             return;
         }
     }
-    //uprintf("  match found!!!\n");
-    // Save payload data in result, with sequence and completion strings
+    // Save payload data and max_transform_len in result
     search->max_transform_len = clen;
     res->payload = *payload;
-    st_key_stack_to_str(trie->key_stack, res->sequence);
-    char *completion_str = res->completion;
-    for (int i = payload->completion_index; i < completion_end; ++i) {
-        *completion_str++ = CDATA(i);
+    // Fill the result sequence and start of transform
+    char *seq = res->sequence;
+    char *transform = res->transform;
+    for (int i = trie->key_stack->size - 1; i >= 0; --i) {
+        const uint16_t keycode = trie->key_stack->buffer[i];
+        const char c = st_keycode_to_char(keycode);
+        *seq++ = c;
+        if (i >= 1 + payload->num_backspaces) {
+            *transform++ = c;
+        }
     }
-    *completion_str = 0;
+    *seq = 0;
+    // Finish writing transform
+    for (int i = payload->completion_index; i < completion_end; ++i) {
+        *transform++ = CDATA(i);
+    }
+    *transform = 0;
  }

--- a/trie.c
+++ b/trie.c
@@ -9,8 +9,11 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>
+#include <ctype.h>
 #include "keybuffer.h"
+#include "key_stack.h"
 #include "trie.h"
+#include "utils.h"
 #include "print.h"
 
 #define TRIE_MATCH_BIT      0x8000
@@ -18,6 +21,7 @@
 #define TRIE_CODE_MASK      0x3FFF
 
 #define TDATA(L) pgm_read_word(&trie->data[L])
+#define CDATA(L) pgm_read_byte(&trie->completions[L])
 
 //////////////////////////////////////////////////////////////////
 bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res)
@@ -110,3 +114,138 @@ bool st_find_longest_chain(st_trie_t *trie, st_key_buffer_t *search, st_trie_pay
 	// After a chain, there should be a leaf or branch
 	return st_find_longest_chain(trie, search, res, offset+1, depth);
 }
+//////////////////////////////////////////////////////////////////////
+uint8_t st_trie_get_rule(st_trie_t             *trie,
+                         const st_key_buffer_t *key_buffer,
+                         uint8_t               search_len_start,
+                         st_trie_rule_t        *res)
+{
+	st_trie_search_t search;
+    search.trie = trie;
+    search.key_buffer = key_buffer;
+    search.result = res;
+    search.max_completed_chars = 0;    
+    const uint8_t max_skip_levels = 1 + trie->max_backspaces;
+	for (uint8_t len = search_len_start; len < key_buffer->context_len; ++len) {
+		// For every base search_len, increase skip_levels until we find a match.
+		// Each skip level allows for a magic key or deleted char.
+		for (search.skip_levels = 1; search.skip_levels <= max_skip_levels; ++search.skip_levels) {
+			search.search_len = len + search.skip_levels;
+			trie->key_stack->size = 0;
+			st_find_rule(&search, 0);
+			if (search.max_completed_chars) {
+                return len + res->payload.completion_len;
+			}
+		}
+	}
+	return search_len_start;
+}
+//////////////////////////////////////////////////////////////////////
+bool st_find_rule(st_trie_search_t *search, uint16_t offset)
+{
+    // Simulate future buffer keys by offsetting buffer access
+#define OFFSET_BUFFER_VAL st_key_buffer_get_keycode(key_buffer, (int)key_stack->size - (int)search->search_len)
+    st_trie_t *trie = search->trie;
+    const st_key_buffer_t *key_buffer = search->key_buffer;
+    st_key_stack_t *key_stack = trie->key_stack;    
+    uint16_t code = TDATA(offset);
+	// Match Node if bit 15 is set
+	if (code & TRIE_MATCH_BIT) {
+		// If bit 14 is also set, there's a child node after the completion string
+		if ((code & TRIE_BRANCH_BIT) && st_find_rule(search, offset+2))
+			return true;
+        // If no better match found deeper,
+        // inspect this payload to see if the rule would match
+        st_trie_payload_t payload;
+        st_get_payload_from_code(&payload, code, TDATA(offset + 1));
+        // Make sure skip_levels matches 1 magic key + backspaces,
+        // and that removing those wouldn't leave us with an empty context
+        const uint8_t skips = 1 + payload.num_backspaces;
+        if (search->skip_levels != skips || key_stack->size <= skips)
+            return false;
+        st_check_rule_match(&payload, search);
+		// Found a match so return true!
+		return true;
+	}
+	// BRANCH node if bit 14 is set
+	if (code & TRIE_BRANCH_BIT) {
+		if (key_stack->size >= search->search_len)
+			return false;
+		code &= TRIE_CODE_MASK;
+		bool res = false;
+		const bool check = key_stack->size >= search->skip_levels;
+        const uint16_t cur_key = check ? OFFSET_BUFFER_VAL : 0;
+		// find child that matches our current buffer location
+		// (if this is a skip level, we go down all children)
+		for (; code; offset += 2, code = TDATA(offset)) {
+			if (!check || cur_key == code) {
+				// Get 16bit offset to child node
+				const int child_offset = TDATA(offset + 1);
+				// Traverse down child node
+				st_key_stack_push(key_stack, code);
+				res = st_find_rule(search, child_offset) || res;
+				st_key_stack_pop(key_stack);
+				if (check)
+					return res;
+			}
+		}
+		return res;
+	}
+	// No high bits set, so this is a chain node
+	// Travel down chain until we reach a zero code, or we no longer match our buffer
+	const int prev_stack_size = key_stack->size;
+	for (; code; code = TDATA(++offset)) {
+        if (key_stack->size >= search->search_len) {
+			key_stack->size = prev_stack_size;
+			return false;
+		}
+        const bool check = key_stack->size >= search->skip_levels;
+        const uint16_t cur_key = check ? OFFSET_BUFFER_VAL : 0;
+        if (check && cur_key != code) {
+			key_stack->size = prev_stack_size;
+			return false;
+		}
+		st_key_stack_push(key_stack, code);		
+	}
+	// After a chain, there should be a leaf or branch
+	const bool res = st_find_rule(search, offset+1);
+	key_stack->size = prev_stack_size;
+	return res;
+}
+//////////////////////////////////////////////////////////////////////
+void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search)
+{
+    st_trie_t *trie = search->trie;
+    st_trie_rule_t *res = search->result;
+    //uprintf("checking match at index %d\n", payload->completion_index);
+    // Early return if:
+    // 1. potential completed len is smaller than our current best
+    // 2. potential completed len overflows search buffer
+    uint8_t clen = search->search_len - search->skip_levels;
+    const uint8_t clen_end = clen + payload->completion_len;
+    if (clen_end < search->max_completed_chars ||
+        clen_end > search->key_buffer->context_len)
+        return;
+    //uprintf("  testing completion: ");
+    // Check if completed string matches what comes next in our search buffer
+    const uint16_t completion_end = payload->completion_index + payload->completion_len;
+    char *completion_str = res->completion;
+    for (uint16_t i = payload->completion_index; i < completion_end; ++i, ++clen) {
+        const char ascii_code = CDATA(i);
+        // Save to ascii completion string at the same time
+        *completion_str++ = ascii_code;       
+        const uint16_t keycode = st_char_to_keycode(tolower(ascii_code));
+        const uint16_t buffer_keycode = st_key_buffer_get_keycode(search->key_buffer, -(clen+1));
+        //uprintf("[%02X, %02X] ", keycode, buffer_keycode);
+        if (keycode != buffer_keycode) {
+            //uprintf("  no match.\n");
+            return;
+        }
+    }
+    *completion_str = 0;
+    //uprintf("  match found!!!\n");
+    // Mark winning info in search struct, and write the rule string
+    search->max_completed_chars = clen;
+    res->payload = *payload;
+    st_key_stack_to_str(trie->key_stack, res->rule);
+ }

--- a/trie.h
+++ b/trie.h
@@ -34,7 +34,7 @@ typedef struct
 typedef struct
 {
     st_trie_payload_t   payload;
-    char                *rule;
+    char                *sequence;
     char                *completion;
 } st_trie_rule_t;
 
@@ -50,7 +50,7 @@ typedef struct
     const st_key_buffer_t   *key_buffer;            // search buffer
     int                     search_len;             // amount of buffer (from oldest key) to use when searching
     int                     skip_levels;	        // number of trie levels to 'skip' when searching
-    int                     max_completed_chars;    // keeps track of best result
+    int                     max_transform_len;      // keeps track of best result
     st_trie_rule_t          *result;                // pointer to result to be filled with best match
 } st_trie_search_t;
 

--- a/trie.h
+++ b/trie.h
@@ -28,7 +28,6 @@ typedef struct
     uint8_t     completion_len;     // length of completion string
     uint8_t     num_backspaces;     // number of backspaces to send before the completion string
     uint8_t     func_code;          // special function code
-    uint8_t     context_match_len;  // amount of context keys matched from full search buffer
 } st_trie_payload_t;
 
 typedef struct

--- a/trie.h
+++ b/trie.h
@@ -39,7 +39,7 @@ typedef struct
 } st_trie_rule_t;
 
 bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_payload_t *res);
-uint8_t st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, uint8_t search_len_start, st_trie_rule_t *res);
+int st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, int search_len_start, st_trie_rule_t *res);
 
 //////////////////////////////////////////////////////////////////
 // Internal
@@ -47,10 +47,10 @@ uint8_t st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, uin
 typedef struct 
 {
     st_trie_t               *trie;                  // trie to search
-	const st_key_buffer_t   *key_buffer;            // search buffer
-    uint8_t                 search_len;             // amount of buffer (from oldest key) to use when searching
-	uint8_t                 skip_levels;	        // number of trie levels to 'skip' when searching
-    uint8_t                 max_completed_chars;     // keeps track of best result
+    const st_key_buffer_t   *key_buffer;            // search buffer
+    int                     search_len;             // amount of buffer (from oldest key) to use when searching
+    int                     skip_levels;	        // number of trie levels to 'skip' when searching
+    int                     max_completed_chars;    // keeps track of best result
     st_trie_rule_t          *result;                // pointer to result to be filled with best match
 } st_trie_search_t;
 

--- a/trie.h
+++ b/trie.h
@@ -34,7 +34,7 @@ typedef struct
 {
     st_trie_payload_t   payload;
     char                *sequence;
-    char                *completion;
+    char                *transform;
 } st_trie_rule_t;
 
 typedef struct

--- a/utils.c
+++ b/utils.c
@@ -93,3 +93,13 @@ void st_send_key(uint16_t keycode)
 #endif
     tap_code16(keycode);
 }
+//////////////////////////////////////////////////////////////////////
+int st_max(int a, int b)
+{
+    return (a > b ? a : b);
+}
+//////////////////////////////////////////////////////////////////////
+int st_min(int a, int b)
+{
+    return (a < b ? a : b);
+}

--- a/utils.c
+++ b/utils.c
@@ -16,6 +16,8 @@
 
 // TODO: define this in generated .h file
 static const char magic_chars[] = {'M', 'R'};
+static const char *st_seq_tokens[] = {"☆", "✪"};
+static const char *st_wordbreak_token = "␣";
 
 static const char unshifted_keycode_to_ascii_lut[53] PROGMEM = {
 //                                  KC_A    KC_B    KC_C    KC_D
@@ -54,6 +56,30 @@ static const char shifted_keycode_to_ascii_lut[53] PROGMEM = {
     '?'
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// copies src to dest and returns pointer to the new end of dest
+// (null terminator is written at end address)
+char *st_strcpy(char *dest, const char *src)
+{
+    // st_assert(dest != 0 && src != 0);
+    while (*src) {
+        *dest++ = *src++;
+    }
+    *dest = 0;
+    return dest;
+}
+////////////////////////////////////////////////////////////////////////////////
+// if keycode is a token that can be translated back to its user symbol,
+// returns pointer to it, otherwise returns 0
+const char *st_get_seq_token_symbol(uint16_t keycode)
+{
+    if (SPECIAL_KEY_TRIECODE_0 <= keycode && keycode < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT) {
+        return st_seq_tokens[keycode - SPECIAL_KEY_TRIECODE_0];        
+    } else if (keycode == KC_SPACE) {
+        return st_wordbreak_token;
+    }
+    return 0;
+}
 ////////////////////////////////////////////////////////////////////////////////
 char st_keycode_to_char(uint16_t keycode)
 {

--- a/utils.c
+++ b/utils.c
@@ -15,9 +15,8 @@
 #define PGM_LOADBIT(mem, pos) ((pgm_read_byte(&((mem)[(pos) / 8])) >> ((pos) % 8)) & 0x01)
 
 // TODO: define this in generated .h file
-static const char magic_chars[] = {'M', 'R'};
-static const char *st_seq_tokens[] = {"☆", "✪"};
-static const char *st_wordbreak_token = "␣";
+static const char st_seq_tokens_ascii[] = {'*', '@', '$', '#'};
+static const char st_wordbreak_ascii = '^';
 
 static const char unshifted_keycode_to_ascii_lut[53] PROGMEM = {
 //                                  KC_A    KC_B    KC_C    KC_D
@@ -57,34 +56,13 @@ static const char shifted_keycode_to_ascii_lut[53] PROGMEM = {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-// copies src to dest and returns pointer to the new end of dest
-// (null terminator is written at end address)
-char *st_strcpy(char *dest, const char *src)
-{
-    // st_assert(dest != 0 && src != 0);
-    while (*src) {
-        *dest++ = *src++;
-    }
-    *dest = 0;
-    return dest;
-}
-////////////////////////////////////////////////////////////////////////////////
-// if keycode is a token that can be translated back to its user symbol,
-// returns pointer to it, otherwise returns 0
-const char *st_get_seq_token_symbol(uint16_t keycode)
-{
-    if (SPECIAL_KEY_TRIECODE_0 <= keycode && keycode < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT) {
-        return st_seq_tokens[keycode - SPECIAL_KEY_TRIECODE_0];        
-    } else if (keycode == KC_SPACE) {
-        return st_wordbreak_token;
-    }
-    return 0;
-}
-////////////////////////////////////////////////////////////////////////////////
 char st_keycode_to_char(uint16_t keycode)
 {
-    if (keycode >= SPECIAL_KEY_TRIECODE_0 && keycode < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT)
-		return magic_chars[keycode - SPECIAL_KEY_TRIECODE_0];
+    if (keycode >= SPECIAL_KEY_TRIECODE_0 && keycode < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT) {
+		return st_seq_tokens_ascii[keycode - SPECIAL_KEY_TRIECODE_0];
+    } else if (keycode == KC_SPACE) {
+        return st_wordbreak_ascii;
+    }
     const bool shifted = keycode & QK_LSFT;
     keycode &= 0xFF;
     if (keycode >= KC_A && keycode <= KC_SLASH) {

--- a/utils.c
+++ b/utils.c
@@ -87,7 +87,7 @@ void st_multi_tap(uint16_t keycode, int count)
 void st_send_key(uint16_t keycode)
 {
     // Apply shift to sent key if caps word is enabled.
-#ifdef CAPS_WORD_ENABLED
+#ifdef CAPS_WORD_ENABLE
     if (is_caps_word_on() && IS_ALPHA_KEYCODE(keycode))
         add_weak_mods(MOD_BIT(KC_LSFT));
 #endif

--- a/utils.c
+++ b/utils.c
@@ -129,3 +129,8 @@ int st_min(int a, int b)
 {
     return (a < b ? a : b);
 }
+//////////////////////////////////////////////////////////////////////
+int st_clamp(int val, int min_val, int max_val)
+{
+    return (val < min_val ? min_val : (val > max_val ? max_val : val));
+}

--- a/utils.h
+++ b/utils.h
@@ -13,6 +13,8 @@
 
 #define IS_ALPHA_KEYCODE(code) ((code) >= KC_A && (code) <= KC_Z)
 
+const char  *st_get_seq_token_symbol(uint16_t keycode);
+char        *st_strcpy(char *dest, const char *src);
 uint16_t    st_char_to_keycode(char c);
 char        st_keycode_to_char(uint16_t keycode);
 void        st_multi_tap(uint16_t keycode, int count);

--- a/utils.h
+++ b/utils.h
@@ -21,3 +21,4 @@ void        st_multi_tap(uint16_t keycode, int count);
 void        st_send_key(uint16_t keycode);
 int         st_max(int a, int b);
 int         st_min(int a, int b);
+int         st_clamp(int val, int min_val, int max_val);

--- a/utils.h
+++ b/utils.h
@@ -13,7 +13,9 @@
 
 #define IS_ALPHA_KEYCODE(code) ((code) >= KC_A && (code) <= KC_Z)
 
-uint16_t st_char_to_keycode(char c);
-char st_keycode_to_char(uint16_t keycode);
-void st_multi_tap(uint16_t keycode, int count);
-void st_send_key(uint16_t keycode);
+uint16_t    st_char_to_keycode(char c);
+char        st_keycode_to_char(uint16_t keycode);
+void        st_multi_tap(uint16_t keycode, int count);
+void        st_send_key(uint16_t keycode);
+int         st_max(int a, int b);
+int         st_min(int a, int b);

--- a/utils.h
+++ b/utils.h
@@ -13,8 +13,6 @@
 
 #define IS_ALPHA_KEYCODE(code) ((code) >= KC_A && (code) <= KC_Z)
 
-const char  *st_get_seq_token_symbol(uint16_t keycode);
-char        *st_strcpy(char *dest, const char *src);
 uint16_t    st_char_to_keycode(char c);
 char        st_keycode_to_char(uint16_t keycode);
 void        st_multi_tap(uint16_t keycode, int count);


### PR DESCRIPTION
This update shows you missed rules as you type.
The search starts from after any previously found rule's completion, and finds the next longest completion from the smallest amount of key buffer context. Backspaces and buffer reset are handled.
The `st_on_missed_rule` callback function has a weak attribute so that the user can override it. By default it just prints the rule to the console.
To test this, add `#define SEQUENCE_TRANSFORM_MISSED_RULES` to your layout's config.h file, and `SRC += sequence_transform/key_stack.c` to your rules.mk file.