### PR TITLE
prevent under and overflow errors with uints

### DIFF
--- a/keybuffer.c
+++ b/keybuffer.c
@@ -27,13 +27,13 @@
 //   st_key_buffer_get(buf, -2) -> b
 //   st_key_buffer_get(buf, -3) -> c
 // returns KC_NO if index is out of bounds
-uint16_t st_key_buffer_get_keycode(st_key_buffer_t *buf, int index)
+uint16_t st_key_buffer_get_keycode(const st_key_buffer_t *buf, int index)
 {
     const st_key_action_t *keyaction = st_key_buffer_get(buf, index);
     return (keyaction ? keyaction->keypressed : KC_NO);
 }
 //////////////////////////////////////////////////////////////////
-st_key_action_t *st_key_buffer_get(st_key_buffer_t *buf, int index)
+st_key_action_t *st_key_buffer_get(const st_key_buffer_t *buf, int index)
 {
     if (index < 0) {
         index += buf->context_len;
@@ -47,7 +47,7 @@ st_key_action_t *st_key_buffer_get(st_key_buffer_t *buf, int index)
     return &buf->data[
         buf->cur_pos >= index
             ? buf->cur_pos - index
-            : buf->cur_pos - index + buf->size //wrap around
+            : buf->size + index - buf->cur_pos //wrap around
     ];
 }
 //////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ void st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num)
     }
 }
 //////////////////////////////////////////////////////////////////
-void st_key_buffer_print(st_key_buffer_t *buf)
+void st_key_buffer_print(const st_key_buffer_t *buf)
 {
     uprintf("buffer: |");
     for (int i = -1; i >= -buf->context_len; --i)
@@ -98,7 +98,7 @@ void st_key_buffer_print(st_key_buffer_t *buf)
     uprintf("| (%d)\n", buf->context_len);
 }
 //////////////////////////////////////////////////////////////////
-void st_key_buffer_to_str(st_key_buffer_t *buf, char* output_string, uint8_t len)
+void st_key_buffer_to_str(const st_key_buffer_t *buf, char* output_string, uint8_t len)
 {
     int i = 0;
 

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -22,16 +22,16 @@ typedef struct
 {
     st_key_action_t     *data;       // array of keycodes
     // TODO rename to capacity
-    uint8_t             size;        // buffer size
+    int             size;        // buffer size
     // TODO rename to size
-    uint8_t             context_len; // number of current keys in buffer
-    uint8_t             cur_pos;
+    int             context_len; // number of current keys in buffer
+    int             cur_pos;
 } st_key_buffer_t;
 
-st_key_action_t         *st_key_buffer_get(st_key_buffer_t *buf, int index);
-uint16_t                st_key_buffer_get_keycode(st_key_buffer_t *buf, int index);
+st_key_action_t         *st_key_buffer_get(const st_key_buffer_t *buf, int index);
+uint16_t                st_key_buffer_get_keycode(const st_key_buffer_t *buf, int index);
 void                    st_key_buffer_reset(st_key_buffer_t *buf);
 void                    st_key_buffer_push(st_key_buffer_t *buf, uint16_t keycode);
 void                    st_key_buffer_pop(st_key_buffer_t *buf, uint8_t num);
-void                    st_key_buffer_print(st_key_buffer_t *buf);
-void                    st_key_buffer_to_str(st_key_buffer_t *buf, char* output_string, uint8_t len);
+void                    st_key_buffer_print(const st_key_buffer_t *buf);
+void                    st_key_buffer_to_str(const st_key_buffer_t *buf, char* output_string, uint8_t len);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -21,10 +21,19 @@
 
 //////////////////////////////////////////////////////////////////
 // Key history buffer
-static st_key_action_t key_buffer_data[SEQUENCE_MAX_LENGTH] = {{KC_SPC, ST_DEFAULT_KEY_ACTION}};
+#ifdef SEQUENCE_TRANSFORM_EXTRA_BUFFER
+#   if SEQUENCE_MAX_LENGTH + COMPLETION_MAX_LENGTH + SEQUENCE_TRANSFORM_EXTRA_BUFFER < 256
+#       define KEY_BUFFER_CAPACITY SEQUENCE_MAX_LENGTH + COMPLETION_MAX_LENGTH + SEQUENCE_TRANSFORM_EXTRA_BUFFER
+#   else
+#       define KEY_BUFFER_CAPACITY 255
+#   endif
+#else
+#   define KEY_BUFFER_CAPACITY SEQUENCE_MAX_LENGTH + COMPLETION_MAX_LENGTH
+#endif
+static st_key_action_t key_buffer_data[KEY_BUFFER_CAPACITY] = {{KC_SPC, ST_DEFAULT_KEY_ACTION}};
 static st_key_buffer_t key_buffer = {
     key_buffer_data,
-    SEQUENCE_MAX_LENGTH,
+    KEY_BUFFER_CAPACITY,
     1
 };
 
@@ -186,7 +195,7 @@ void log_rule(st_trie_t *trie, st_trie_payload_t *res) {
     char context_string[SEQUENCE_MAX_LENGTH + 1];
     st_key_buffer_to_str(&key_buffer, context_string, res->context_match_len);
 
-    char rule_trigger_char = context_string[res->context_match_len - 1]; 
+    char rule_trigger_char = context_string[res->context_match_len - 1];
     context_string[res->context_match_len - 1] = '\0';
 
     // TODO remove 'R' hardcode
@@ -201,7 +210,7 @@ void log_rule(st_trie_t *trie, st_trie_payload_t *res) {
 
     uprintf("st_rule,%s,%d,%c,", context_string, res->num_backspaces, rule_trigger_char);
 
-    // Completion string 
+    // Completion string
     const uint16_t completion_end = res->completion_index + res->completion_len;
 
     for (uint16_t i = res->completion_index; i < completion_end; ++i) {


### PR DESCRIPTION
Unifying fixes from the two outstanding PRs to make the eventual merges smaller.