### PR TITLE
Incorrect buffer clear circumstances

### DIFF
--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -93,7 +93,7 @@ bool st_process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods) {
                 *mods |= MOD_RSFT;
             }
             *keycode = QK_MODS_GET_BASIC_KEYCODE(*keycode); // Get the basic keycode.
-            return true;
+            break;
 #ifndef NO_ACTION_TAPPING
         // Exclude tap-hold keys when they are held down
         // and mask for base keycode when they are tapped.

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -79,12 +79,11 @@ bool st_process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods) {
             return false;
 
         // bake shift mod into keycode symbols
-        case KC_1 ... KC_0:
-        case KC_MINUS ... KC_SLASH:
+        case KC_1 ... KC_SLASH:
             if (*mods & MOD_MASK_SHIFT) {
                 *keycode |= QK_LSFT;
             }
-            return true;
+            break;
         // Clear shift for alphas
         case LSFT(KC_A) ... LSFT(KC_Z):
         case RSFT(KC_A) ... RSFT(KC_Z):

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -79,7 +79,8 @@ bool st_process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods) {
             return false;
 
         // bake shift mod into keycode symbols
-        case KC_1 ... KC_SLASH:
+        case KC_1 ... KC_0:
+        case KC_MINUS ... KC_SLASH:
             if (*mods & MOD_MASK_SHIFT) {
                 *keycode |= QK_LSFT;
             }


### PR DESCRIPTION
Keys in that range ignore `(*mods & ~MOD_MASK_SHIFT) != 0` condition after the switch so `ctrl + backspace` didnt clear the buffer because `KC_1 ... KC_SLASH` contains `KC_BACKSPACE`

~~It works in this case, but im not sure if we should actually just return true there ignoring other mods, have to think about it more probably, like `ctrl + 1` also wont clear the buffer~~

^ irrelevant after the second commit