### PR TITLE
Process undo on immediate press of backspace

### DIFF
--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -200,6 +200,7 @@ void st_handle_repeat_key()
     }
 }
 ///////////////////////////////////////////////////////////////////////////////
+#if defined(RECORD_RULE_USAGE) && defined(CONSOLE_ENABLE)
 void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
     // Main body
     char context_string[SEQUENCE_MAX_LENGTH + 1];
@@ -243,6 +244,7 @@ void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
     // Terminator
     uprintf("\n");
 }
+#endif
 //////////////////////////////////////////////////////////////////////////////////////////
 void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
 #ifdef SEQUENCE_TRANSFORM_LOG_GENERAL

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -18,6 +18,7 @@
 // Public API
 
 bool process_sequence_transform(uint16_t keycode, keyrecord_t *record, uint16_t special_key_start);
+void post_process_sequence_transform(void);
 
 #if SEQUENCE_TRANSFORM_IDLE_TIMEOUT > 0
 void sequence_transform_task(void);


### PR DESCRIPTION
We now immediately process the undo on a pressed event for backspace.

If the backspace is later detected to have been held longer than the tapping term, we clear the buffer.

In order to make this work, we send a sacrificial space character to the output so that the normally processed backspace later down the QMK chain doesn't mess up our undo.