### PR TITLE
Fallback cleanup

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -170,9 +170,8 @@ bool st_cursor_longer_than(const st_cursor_t *cursor, const st_cursor_pos_t *pas
 {
     const int cur_pos = (cursor->cursor_pos.pos << 8)
         + cursor->cursor_pos.sub_pos;
-    // FIXME: is it intended that we're not using sub_pos for this one?
     const int old_pos = (past_pos->pos << 8)
-        + past_pos->pos;
+        + past_pos->sub_pos;
     return cur_pos > old_pos;
 }
 //////////////////////////////////////////////////////////////////

--- a/cursor.h
+++ b/cursor.h
@@ -8,18 +8,16 @@
 // Original source/inspiration: https://getreuer.info/posts/keyboards/autocorrection
 #pragma once
 
-#include "trie.h"
-
 //////////////////////////////////////////////////////////////////
 // Public API
 
-void                    st_cursor_init(const st_trie_t *trie, st_key_buffer_t *buf, int history, uint8_t as_output_buffer);
+void                    st_cursor_init(st_cursor_t *cursor, st_key_buffer_t *buf, int history, uint8_t as_output_buffer);
 uint16_t                st_cursor_get_keycode(const st_trie_t *trie);
 st_trie_payload_t       *st_cursor_get_action(const st_trie_t *trie);
 bool                    st_cursor_next(const st_trie_t *trie);
-bool                    st_cursor_move_to_history(const st_trie_t *trie, int history, uint8_t as_output_buffer);
-st_cursor_pos_t         st_cursor_save(const st_trie_t *trie);
-void                    st_cursor_restore(const st_trie_t *trie, st_cursor_pos_t *cursor_pos);
-bool                    st_cursor_longer_than(const st_trie_t *trie, st_cursor_pos_t *past_pos);
+bool                    st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
+st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
+void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);
+bool                    st_cursor_longer_than(const st_trie_t *trie, const st_cursor_pos_t *past_pos);
 bool                    st_cursor_push_to_stack(const st_trie_t *trie, int count);
 void                    st_cursor_print(const st_trie_t *trie);

--- a/cursor.h
+++ b/cursor.h
@@ -11,13 +11,13 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
-void                    st_cursor_init(st_cursor_t *cursor, st_key_buffer_t *buf, int history, uint8_t as_output_buffer);
-uint16_t                st_cursor_get_keycode(const st_trie_t *trie);
-st_trie_payload_t       *st_cursor_get_action(const st_trie_t *trie);
-bool                    st_cursor_next(const st_trie_t *trie);
+void                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
+uint16_t                st_cursor_get_keycode(st_cursor_t *trie);
+st_trie_payload_t       *st_cursor_get_action(st_cursor_t *trie);
+bool                    st_cursor_next(st_cursor_t *trie);
 bool                    st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
 st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
 void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);
-bool                    st_cursor_longer_than(const st_trie_t *trie, const st_cursor_pos_t *past_pos);
-bool                    st_cursor_push_to_stack(const st_trie_t *trie, int count);
-void                    st_cursor_print(const st_trie_t *trie);
+bool                    st_cursor_longer_than(const st_cursor_t *cursor, const st_cursor_pos_t *past_pos);
+bool                    st_cursor_push_to_stack(st_cursor_t *cursor, int count);
+void                    st_cursor_print(st_cursor_t *cursor);

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -19,6 +19,7 @@ typedef struct
     uint16_t keypressed;
     uint16_t action_taken;
 } st_key_action_t;
+
 typedef struct
 {
     st_key_action_t * const data;        // array of keycodes

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -242,12 +242,12 @@ void st_handle_repeat_key(void)
 ///////////////////////////////////////////////////////////////////////////////
 void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
 #if defined(RECORD_RULE_USAGE) && defined(CONSOLE_ENABLE)
-    st_cursor_init(trie, &key_buffer, 0, false);
+    st_cursor_init(trie->cursor, &key_buffer, 0, false);
     const uint16_t rule_trigger_keycode = st_cursor_get_keycode(trie);
     const st_trie_payload_t *rule_action = st_cursor_get_action(trie);
     const bool is_repeat = rule_action->func_code == 1;
     const int prev_seq_len = res->trie_match.seq_match_pos.segment_len - 1;
-    st_cursor_move_to_history(trie, 1, res->trie_match.seq_match_pos.as_output_buffer);
+    st_cursor_move_to_history(trie->cursor, 1, res->trie_match.seq_match_pos.as_output_buffer);
     st_cursor_push_to_stack(trie, prev_seq_len);
     char seq_str[prev_seq_len + 1];
     st_key_stack_to_str(trie->key_stack, seq_str);
@@ -363,7 +363,7 @@ void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
 //////////////////////////////////////////////////////////////////////////////////////////
 #ifndef SEQUENCE_TRANSFORM_DISABLE_ENHANCED_BACKSPACE
 void st_handle_backspace() {
-    st_cursor_init(&trie, &key_buffer, 0, true);
+    st_cursor_init(trie.cursor, &key_buffer, 0, true);
     const st_trie_payload_t *action = st_cursor_get_action(&trie);
     if (action->completion_index == ST_DEFAULT_KEY_ACTION) {
         // previous key-press didn't trigger a rule action. One total backspace required
@@ -391,7 +391,7 @@ void st_handle_backspace() {
 #endif
     // If previous action used backspaces, restore the deleted output from earlier actions
     if (resend_count > 0) {
-        st_cursor_move_to_history(&trie, 1, true);
+        st_cursor_move_to_history(trie.cursor, 1, true);
         if (st_cursor_push_to_stack(&trie, resend_count)) {
             // Send backspaces now that we know we can do the full undo
             st_multi_tap(KC_BSPC, backspaces_needed_count);
@@ -415,7 +415,7 @@ void st_handle_backspace() {
  */
 uint8_t st_get_virtual_output(char *buf, uint8_t count)
 {
-    st_cursor_init(&trie, &key_buffer, 0, true);
+    st_cursor_init(trie.cursor, &key_buffer, 0, true);
     for (int i = 0; i < count; ++i, st_cursor_next(&trie)) {
         const uint16_t keycode = st_cursor_get_keycode(&trie);
         if (!keycode) {

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -67,20 +67,12 @@ void sequence_transform_task(void) {
 
 //////////////////////////////////////////////////////////////////
 // Trie key stack
-static uint16_t trie_key_stack_data[MAX(SEQUENCE_MAX_LENGTH, MAX_BACKSPACES)] = {0};
+#define ST_STACK_SIZE MAX(SEQUENCE_MAX_LENGTH, MAX_BACKSPACES)
+static uint16_t trie_key_stack_data[ST_STACK_SIZE] = {0};
 static st_key_stack_t trie_stack = {
     trie_key_stack_data,
-    SEQUENCE_MAX_LENGTH,
+    ST_STACK_SIZE,
     0
-};
-
-//////////////////////////////////////////////////////////////////
-// Trie cursor
-static st_cursor_t trie_cursor = {
-    &key_buffer,
-    {0, 255,0, false},
-    {0},
-    false,
 };
 
 //////////////////////////////////////////////////////////////////
@@ -92,8 +84,17 @@ static st_trie_t trie = {
     sequence_transform_completions_data,
     COMPLETION_MAX_LENGTH,
     MAX_BACKSPACES,
-    &trie_stack,
-    &trie_cursor
+    &trie_stack
+};
+
+//////////////////////////////////////////////////////////////////
+// Trie cursor
+static st_cursor_t trie_cursor = {
+    &key_buffer,
+    &trie,
+    {0, 255,0, false},
+    {0},
+    false,
 };
 
 //////////////////////////////////////////////////////////////////
@@ -242,12 +243,12 @@ void st_handle_repeat_key(void)
 ///////////////////////////////////////////////////////////////////////////////
 void log_rule(st_trie_t *trie, st_trie_search_result_t *res) {
 #if defined(RECORD_RULE_USAGE) && defined(CONSOLE_ENABLE)
-    st_cursor_init(trie->cursor, &key_buffer, 0, false);
+    st_cursor_init(&trie_cursor, 0, false);
     const uint16_t rule_trigger_keycode = st_cursor_get_keycode(trie);
     const st_trie_payload_t *rule_action = st_cursor_get_action(trie);
     const bool is_repeat = rule_action->func_code == 1;
     const int prev_seq_len = res->trie_match.seq_match_pos.segment_len - 1;
-    st_cursor_move_to_history(trie->cursor, 1, res->trie_match.seq_match_pos.as_output_buffer);
+    st_cursor_move_to_history(&trie_cursor, 1, res->trie_match.seq_match_pos.as_output_buffer);
     st_cursor_push_to_stack(trie, prev_seq_len);
     char seq_str[prev_seq_len + 1];
     st_key_stack_to_str(trie->key_stack, seq_str);
@@ -363,8 +364,8 @@ void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
 //////////////////////////////////////////////////////////////////////////////////////////
 #ifndef SEQUENCE_TRANSFORM_DISABLE_ENHANCED_BACKSPACE
 void st_handle_backspace() {
-    st_cursor_init(trie.cursor, &key_buffer, 0, true);
-    const st_trie_payload_t *action = st_cursor_get_action(&trie);
+    st_cursor_init(&trie_cursor, 0, true);
+    const st_trie_payload_t *action = st_cursor_get_action(&trie_cursor);
     if (action->completion_index == ST_DEFAULT_KEY_ACTION) {
         // previous key-press didn't trigger a rule action. One total backspace required
         if (action->completion_len == 0) {
@@ -391,8 +392,8 @@ void st_handle_backspace() {
 #endif
     // If previous action used backspaces, restore the deleted output from earlier actions
     if (resend_count > 0) {
-        st_cursor_move_to_history(trie.cursor, 1, true);
-        if (st_cursor_push_to_stack(&trie, resend_count)) {
+        st_cursor_move_to_history(&trie_cursor, 1, true);
+        if (st_cursor_push_to_stack(&trie_cursor, resend_count)) {
             // Send backspaces now that we know we can do the full undo
             st_multi_tap(KC_BSPC, backspaces_needed_count);
             // Send saved keys in original order
@@ -415,9 +416,9 @@ void st_handle_backspace() {
  */
 uint8_t st_get_virtual_output(char *buf, uint8_t count)
 {
-    st_cursor_init(trie.cursor, &key_buffer, 0, true);
-    for (int i = 0; i < count; ++i, st_cursor_next(&trie)) {
-        const uint16_t keycode = st_cursor_get_keycode(&trie);
+    st_cursor_init(&trie_cursor, 0, true);
+    for (int i = 0; i < count; ++i, st_cursor_next(&trie_cursor)) {
+        const uint16_t keycode = st_cursor_get_keycode(&trie_cursor);
         if (!keycode) {
             return i;
         }
@@ -434,7 +435,7 @@ uint8_t st_get_virtual_output(char *buf, uint8_t count)
 bool st_perform() {
     // Get completion string from trie for our current key buffer.
     st_trie_search_result_t res = {{0, {0,0,0}}, {0, 0, 0, 0}};
-    if (st_trie_get_completion(&trie, &key_buffer, &res)) {
+    if (st_trie_get_completion(&trie_cursor, &res)) {
         st_handle_result(&trie, &res);
         return true;
     }

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -13,8 +13,8 @@
 #include "action.h"
 #include "keybuffer.h"
 #include "key_stack.h"
-#include "cursor.h"
 #include "trie.h"
+#include "cursor.h"
 
 //////////////////////////////////////////////////////////////////
 // Public API

--- a/tester/test_backspace.c
+++ b/tester/test_backspace.c
@@ -20,7 +20,7 @@ void test_backspace(const st_test_rule_t *rule, st_test_result_t *res)
 {
     static char message[256];
     res->message = message;
-    // Test #2: st_handle_backspace
+    // This expects input and output buffers to have been set by a previous test!
     // Make sure enhanced backspace handling leaves us with an empty
     // output buffer if we send one backspace for every key sent
     sim_st_enhanced_backspace(rule->seq_keycodes);

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -38,7 +38,6 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
 {
     static char message[256];
     res->message = message;
-    // Test #3: st_find_missed_rule
     sim_st_find_missed_rule(rule->seq_keycodes);
     res->pass = !strcmp(missed_rule_transform, rule->transform_str);
     if (res->pass) {

--- a/tester/test_perform.c
+++ b/tester/test_perform.c
@@ -30,7 +30,6 @@ void test_perform(const st_test_rule_t *rule, st_test_result_t *res)
 {
     static char message[256];
     res->message = message;
-    // Test #1: st_perform
     sim_st_perform(rule->seq_keycodes);
     // Ignore spaces at the start of output
     char *output = sim_output_get(true);

--- a/tester/test_virtual_output.c
+++ b/tester/test_virtual_output.c
@@ -10,10 +10,10 @@
 // compare the virtual output buffer state to the sim output buffer
 bool compare_output(char *virtual_output, char *sim_output, int count)
 {
-    // we don't use st_key_buffer_reset(buf) here because
-    // we don't nec want a space at the start of the buffer
     for (int i = 0; i < count; i++) {
-        if ((sim_output[i] == ' ' ? st_wordbreak_ascii : sim_output[i]) != virtual_output[count - 1 - i]) {
+        const char simc = sim_output[i] == ' ' ? st_wordbreak_ascii : sim_output[i];
+        const char virc = virtual_output[count - 1 - i];
+        if (simc != virc) {
             return false;
         }
     }
@@ -22,24 +22,21 @@ bool compare_output(char *virtual_output, char *sim_output, int count)
 //////////////////////////////////////////////////////////////////////
 void test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[300];
+    static char message[512];
     res->message = message;
-    // Test #2: test_virtual_output
-    // sim_st_perform was run in o previous test
-    // Ignore spaces at the start of output
+    // sim_st_perform was run in a previous test
     char *sim_output = sim_output_get(false);
-    // Test virtual output
-    const int expected_len = strlen(sim_output);
+    const int sim_len = sim_output_get_size();
     char virtual_output[256];
-    int length = st_get_virtual_output(virtual_output, 255);
-    if (length != expected_len) {
+    const int virt_len = st_get_virtual_output(virtual_output, 255);
+    if (virt_len != sim_len) {
         res->pass = false;
-        snprintf(message, sizeof(message), "virtual_output incorrect length (%d); expected (%d)", length, expected_len);
+        snprintf(message, sizeof(message), "virt len (%d) != sim len (%d)", virt_len, sim_len);
     }
-    res->pass = compare_output(virtual_output, sim_output, length);
+    res->pass = compare_output(virtual_output, sim_output, virt_len);
     if (res->pass) {
         snprintf(message, sizeof(message), "OK!");
     } else {
-        snprintf(message, sizeof(message), "virtual_output: %s", virtual_output);
+        snprintf(message, sizeof(message), "mismatch! virt: |%s| sim: |%s|", virtual_output, sim_output);
     }
 }

--- a/trie.c
+++ b/trie.c
@@ -13,8 +13,8 @@
 #include <ctype.h>
 #include "keybuffer.h"
 #include "key_stack.h"
-#include "cursor.h"
 #include "trie.h"
+#include "cursor.h"
 #include "utils.h"
 
 #define TRIE_MATCH_BIT      0x8000
@@ -27,10 +27,10 @@
 //////////////////////////////////////////////////////////////////
 bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_search_result_t *res)
 {
-    st_cursor_init(trie, search, 0, false);
+    st_cursor_init(trie->cursor, search, 0, false);
     st_find_longest_chain(trie, &res->trie_match, 0);
 #ifdef SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER
-    st_cursor_init(trie, search, 0, true);
+    st_cursor_init(trie->cursor, search, 0, true);
 
 #ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
     st_cursor_print(trie);
@@ -143,7 +143,7 @@ bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint
             if (st_cursor_longer_than(trie, &longest_match->seq_match_pos)) {
                 longer_match_found = true;
                 longest_match->trie_match_index = offset;
-                longest_match->seq_match_pos = st_cursor_save(trie);
+                longest_match->seq_match_pos = st_cursor_save(trie->cursor);
             }
             // If bit 14 is also set, there is a child node after the completion string
             if (code & TRIE_BRANCH_BIT) {

--- a/trie.c
+++ b/trie.c
@@ -106,8 +106,10 @@ bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, 
 #endif
         // Branch Node (with multiple children) if bit 14 is set
         if (code & TRIE_BRANCH_BIT) {
+#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
             // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT, "Branching Offset: %d; Code: %#04X\n", offset, code);
             uprintf("Branching Offset: %d; Code: %#04X\n", offset, code);
+#endif
             code &= TRIE_CODE_MASK;
             // Find child key that matches the search buffer at the current depth
             const uint16_t cur_key = st_cursor_get_keycode(cursor);
@@ -122,8 +124,10 @@ bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, 
             // No high bits set, so this is a chain node
             // Travel down chain until we reach a zero byte, or we no longer match our buffer
             do {
+#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
                 // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT, "Chaining Offset: %d; Code: %#04X\n", offset, code);
                 uprintf("Chaining Offset: %d; Code: %#04X\n", offset, code);
+#endif
                 if (code != st_cursor_get_keycode(cursor))
                     return longer_match_found;
             } while ((code = TDATA(++offset)) && st_cursor_next(cursor));
@@ -134,9 +138,11 @@ bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, 
         code = TDATA(offset);
         // Match Node if bit 15 is set
         if (code & TRIE_MATCH_BIT) {
+#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
             // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT,...
             uprintf("New Match found: (%d, %d) %d\n", cursor->cursor_pos.pos, cursor->cursor_pos.sub_pos, cursor->cursor_pos.segment_len);
             uprintf("Previous Match: (%d, %d) %d\n", longest_match->seq_match_pos.pos, longest_match->seq_match_pos.sub_pos, longest_match->seq_match_pos.segment_len);
+#endif
             // record this if it is the longest match
             if (st_cursor_longer_than(cursor, &longest_match->seq_match_pos)) {
                 longer_match_found = true;

--- a/trie.c
+++ b/trie.c
@@ -25,20 +25,20 @@
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
 
 //////////////////////////////////////////////////////////////////
-bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_search_result_t *res)
+bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res)
 {
-    st_cursor_init(trie->cursor, search, 0, false);
-    st_find_longest_chain(trie, &res->trie_match, 0);
+    st_cursor_init(cursor, 0, false);
+    st_find_longest_chain(cursor, &res->trie_match, 0);
 #ifdef SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER
-    st_cursor_init(trie->cursor, search, 0, true);
+    st_cursor_init(cursor, 0, true);
 
 #ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
-    st_cursor_print(trie);
+    st_cursor_print(cursor);
 #endif
-    st_find_longest_chain(trie, &res->trie_match, 0);
+    st_find_longest_chain(cursor, &res->trie_match, 0);
 #endif
     if (res->trie_match.seq_match_pos.segment_len > 0) {
-        st_get_payload_from_match_index(trie, &res->trie_payload, res->trie_match.trie_match_index);
+        st_get_payload_from_match_index(cursor->trie, &res->trie_payload, res->trie_match.trie_match_index);
         return true;
     }
     return false;
@@ -61,7 +61,7 @@ void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_
 }
 
 //////////////////////////////////////////////////////////////////////
-bool find_branch_offset(st_trie_t *trie, uint16_t *offset, uint16_t code, uint16_t cur_key)
+bool find_branch_offset(const st_trie_t *trie, uint16_t *offset, uint16_t code, uint16_t cur_key)
 {
     for (; code; *offset += 2, code = TDATA(*offset)) {
         if (code == cur_key) {
@@ -82,8 +82,9 @@ bool find_branch_offset(st_trie_t *trie, uint16_t *offset, uint16_t code, uint16
  * @param depth  current depth in trie
  * @return       true if match found
  */
-bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint16_t offset)
+bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, uint16_t offset)
 {
+    const st_trie_t *trie = cursor->trie;
     bool longer_match_found = false;
     do {
 #ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
@@ -105,12 +106,11 @@ bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint
 #endif
         // Branch Node (with multiple children) if bit 14 is set
         if (code & TRIE_BRANCH_BIT) {
-#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
+            // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT, "Branching Offset: %d; Code: %#04X\n", offset, code);
             uprintf("Branching Offset: %d; Code: %#04X\n", offset, code);
-#endif
             code &= TRIE_CODE_MASK;
             // Find child key that matches the search buffer at the current depth
-            const uint16_t cur_key = st_cursor_get_keycode(trie);
+            const uint16_t cur_key = st_cursor_get_keycode(cursor);
             if (!cur_key) { // exhausted buffer; return
                 return longer_match_found;
             }
@@ -122,12 +122,11 @@ bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint
             // No high bits set, so this is a chain node
             // Travel down chain until we reach a zero byte, or we no longer match our buffer
             do {
-#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
+                // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT, "Chaining Offset: %d; Code: %#04X\n", offset, code);
                 uprintf("Chaining Offset: %d; Code: %#04X\n", offset, code);
-#endif
-                if (code != st_cursor_get_keycode(trie))
+                if (code != st_cursor_get_keycode(cursor))
                     return longer_match_found;
-            } while ((code = TDATA(++offset)) && st_cursor_next(trie));
+            } while ((code = TDATA(++offset)) && st_cursor_next(cursor));
             // After a chain, there should be a match or branch
             ++offset;
         }
@@ -135,15 +134,14 @@ bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint
         code = TDATA(offset);
         // Match Node if bit 15 is set
         if (code & TRIE_MATCH_BIT) {
-#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
-            uprintf("New Match found: (%d, %d) %d\n", trie->cursor->cursor_pos.pos, trie->cursor->cursor_pos.sub_pos, trie->cursor->cursor_pos.segment_len);
+            // TODO: st_debug(ST_LOG_TRIE_SEARCH_BIT,...
+            uprintf("New Match found: (%d, %d) %d\n", cursor->cursor_pos.pos, cursor->cursor_pos.sub_pos, cursor->cursor_pos.segment_len);
             uprintf("Previous Match: (%d, %d) %d\n", longest_match->seq_match_pos.pos, longest_match->seq_match_pos.sub_pos, longest_match->seq_match_pos.segment_len);
-#endif
             // record this if it is the longest match
-            if (st_cursor_longer_than(trie, &longest_match->seq_match_pos)) {
+            if (st_cursor_longer_than(cursor, &longest_match->seq_match_pos)) {
                 longer_match_found = true;
                 longest_match->trie_match_index = offset;
-                longest_match->seq_match_pos = st_cursor_save(trie->cursor);
+                longest_match->seq_match_pos = st_cursor_save(cursor);
             }
             // If bit 14 is also set, there is a child node after the completion string
             if (code & TRIE_BRANCH_BIT) {
@@ -155,7 +153,7 @@ bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint
                 return longer_match_found;
             }
         }
-    } while (st_cursor_next(trie));
+    } while (st_cursor_next(cursor));
     return longer_match_found;
 }
 

--- a/trie.h
+++ b/trie.h
@@ -29,14 +29,6 @@ typedef struct
 
 typedef struct
 {
-    st_key_buffer_t         *buffer;            // buffer
-    st_cursor_pos_t         cursor_pos;         // Contains all position info for the cursor
-    st_trie_payload_t       cached_action;
-    uint8_t                 cache_valid;
-} st_cursor_t;
-
-typedef struct
-{
     size_t          data_size;          // size in words of data buffer
     const uint16_t  *data;              // serialized trie node data
     size_t          completions_size;   // size in bytes of completions data buffer
@@ -44,8 +36,16 @@ typedef struct
     uint8_t         completion_max_len; // max len of all completion strings
     uint8_t         max_backspaces;     // max backspaces for all completions
     st_key_stack_t * const  key_stack;  // key stack used for searches
-    st_cursor_t * const cursor;         // cursor that traverses the buffer
 } st_trie_t;
+
+typedef struct
+{
+    st_key_buffer_t const * const buffer;           // input buffer this cursor traverses
+    st_trie_t const * const       trie;             // trie used for traversing virtual output buffer
+    st_cursor_pos_t               cursor_pos;       // Contains all position info for the cursor
+    st_trie_payload_t             cached_action;
+    uint8_t                       cache_valid;
+} st_cursor_t;
 
 typedef struct
 {
@@ -66,7 +66,7 @@ typedef struct
     st_trie_payload_t   trie_payload;
 } st_trie_search_result_t;
 
-bool st_trie_get_completion(st_trie_t *trie, st_key_buffer_t *search, st_trie_search_result_t *res);
+bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res);
 int st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, int search_len_start, st_trie_rule_t *res);
 
 //////////////////////////////////////////////////////////////////
@@ -86,4 +86,4 @@ void st_get_payload_from_match_index(const st_trie_t *trie, st_trie_payload_t *p
 void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index);
 bool st_find_rule(st_trie_search_t *search, uint16_t offset);
 void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search);
-bool st_find_longest_chain(st_trie_t *trie, st_trie_match_t *longest_match, uint16_t offset);
+bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, uint16_t offset);


### PR DESCRIPTION
Hi Matt,
So tonight I took some time to read the new cursor code!
It's pretty nice. :)

After some analysis, I changed my mind about `st_trie_t` storing a pointer to `st_cursor_t` making sense.
This makes so many things needlessly awkward in the cursor code. First thing that tipped me off was that
all `st_cursor_` functions were taking a `st_trie_t` as argument. This seemed a bit weird to me.

In chat you said you did this because you didn't want to have to pass a st_cursor_t to the trie search function.
But, IMO, this is _exactly_ what we should be doing! :)

The new cursor object exists to traverse a keybuffer and a trie. It is tied to an instance of each of these things.
So IMO it would make more sense instead if the `st_cursor_t` struct held a pointer to the trie and buffer it will traverse.
It would then look more like an iterator object pattern.

The trie struct itself doesn't care what will traverse/examine it, just like it doesn't care about the key buffer that will
be used to search it. So there's no real reason it should be storing a cursor pointer.

(The reason I added a stack to the trie struct was because I needed to statically allocate its buffer using the same 
`SEQUENCE_MAX_LENGTH` size defined only for that particular trie instance we load in `sequence_transform.c.` And not having
the top level code there have to pass a stack object separately from the trie in functions that only need the stack internally.)

So after thinking about it for a bit, I decided to just try rearranging things a bit, to see if it would work/make sense
(and otherwise, to understand why it would not work).

I did this very carefully. Everything still compiles/runs, and all tests still pass.
I made NO changes to existing logic. But the all the cursor functions now take a `st_cursor_t` pointer instead of a `st_trie_t`.
`st_cursor_t` has a pointer to the trie it's traversing, for when it needs to read data from it.
Its init function no longer takes a buffer, as I didn't see any code that actually needed to change the buffer of 
an instanced cursor object. The buffer pointer is now set at construction, just like the trie pointer is. (I made these const
so we can't accidentally change them.) If we want to traverse another (trie, buffer) pair, we create a new cursor.

I also made a couple minor readability changes (there were some pretty long lines).

I think the structures makes more sense this way, AND make the code easier to read/understand. Hence the PR. :)
If you agree, go ahead and merge. If not, let's discuss tomorrow.

PS. maybe we should consider renaming some struct members.
`cursor->cursor_pos.pos` is not the nicest thing to read. :D
Could be `cursor->pos.index` instead for example.