### PR TITLE
[BUGFIX]Cursor handle empty completion

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -89,15 +89,17 @@ uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
     if (!keyaction) {
         return KC_NO;
     }
-    if (cursor->cursor_pos.as_output &&
-        keyaction->action_taken != ST_DEFAULT_KEY_ACTION) {
-        const st_trie_payload_t *action = st_cursor_get_action(cursor);
-        int index = action->completion_index;
-        index += action->completion_len - 1 - cursor->cursor_pos.sub_index;
-        return st_char_to_keycode(CDATA(index));
-    } else {
+    if (!cursor->cursor_pos.as_output
+            || keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
+        // we need the actual key that was pressed
         return keyaction->keypressed;
     }
+    // This is an output cursor focused on rule matching keypress
+    // get the character at the sub_indax of the transform completion
+    const st_trie_payload_t *action = st_cursor_get_action(cursor);
+    int completion_char_index = action->completion_index;
+    completion_char_index += action->completion_len - 1 - cursor->cursor_pos.sub_index;
+    return st_char_to_keycode(CDATA(completion_char_index));
 }
 //////////////////////////////////////////////////////////////////
 // DO NOT USE externally when cursor is initialized to act

--- a/cursor.c
+++ b/cursor.c
@@ -21,6 +21,7 @@ bool cursor_advance_to_valid_output(st_cursor_t *cursor)
 {
     st_trie_payload_t *action = st_cursor_get_action(cursor);
     if (cursor->cursor_pos.sub_index < action->completion_len) {
+        // current sub-index is valid; no need to advance
         return true;
     }
     // we have exceeded the length of the completion string
@@ -58,8 +59,6 @@ bool cursor_advance_to_valid_output(st_cursor_t *cursor)
         }
         backspaces -= action->completion_len - action->num_backspaces;
     }
-    // current sub_index is valid, no need to advance
-    return true;
 }
 //////////////////////////////////////////////////////////////////
 bool st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output)

--- a/cursor.c
+++ b/cursor.c
@@ -62,14 +62,14 @@ bool cursor_advance_to_valid_output(st_cursor_t *cursor)
     return true;
 }
 //////////////////////////////////////////////////////////////////
-bool st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
+bool st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output)
 {
     cursor->cursor_pos.index = history;
-    cursor->cursor_pos.as_output_buffer = as_output_buffer;
-    cursor->cursor_pos.sub_index = as_output_buffer ? 0 : 255;
+    cursor->cursor_pos.as_output = as_output;
+    cursor->cursor_pos.sub_index = as_output ? 0 : 255;
     cursor->cursor_pos.segment_len = 1;
     cursor->cache_valid = false;
-    if (as_output_buffer && !cursor_advance_to_valid_output(cursor)) {
+    if (as_output && !cursor_advance_to_valid_output(cursor)) {
         // This is crazy, but it is theoretically possible that the
         // entire buffer is full of backspaces such that no valid
         // output key exists in the buffer!
@@ -90,7 +90,7 @@ uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
     if (!keyaction) {
         return KC_NO;
     }
-    if (cursor->cursor_pos.as_output_buffer &&
+    if (cursor->cursor_pos.as_output &&
         keyaction->action_taken != ST_DEFAULT_KEY_ACTION) {
         const st_trie_payload_t *action = st_cursor_get_action(cursor);
         int index = action->completion_index;
@@ -133,7 +133,7 @@ bool st_cursor_at_end(const st_cursor_t *cursor)
 //////////////////////////////////////////////////////////////////
 bool st_cursor_next(st_cursor_t *cursor)
 {
-    if (!cursor->cursor_pos.as_output_buffer) {
+    if (!cursor->cursor_pos.as_output) {
         ++cursor->cursor_pos.index;
         cursor->cache_valid = false;
         if (st_cursor_at_end(cursor)) {

--- a/cursor.c
+++ b/cursor.c
@@ -16,6 +16,50 @@
 
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
 
+bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
+{
+    st_trie_payload_t *action = st_cursor_get_action(cursor);
+    if (cursor->cursor_pos.sub_index < action->completion_len) {
+        return true;
+    }
+    // we have exceeded the length of the completion string
+    // advance to the next key that contains output
+    int backspaces = action->num_backspaces;
+    while (true) {
+        // move to next key in buffer
+        if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
+            return false;
+        }
+        cursor->cache_valid = false;
+        st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
+        // Below is an assert that should be made
+        // if (!keyaction) {
+        //     // We reached the end without finding the next output key
+        //     return false;
+        // }
+        if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
+            if (backspaces == 0) {
+                // This is a real keypress and no more backspaces to consume
+                cursor->cursor_pos.sub_index = 0;
+                return true;
+            }
+            // consume one backspace
+            --backspaces;
+            continue;
+        }
+        // Load payload of key that performed action
+        action = st_cursor_get_action(cursor);
+        if (backspaces < action->completion_len) {
+            // This action contains the next output key. Find it's sub_pos and return true
+            cursor->cursor_pos.sub_index = backspaces;
+            return true;
+        }
+        backspaces -= action->completion_len - action->num_backspaces;
+    }
+    // current sub_index is valid, no need to advance
+    return true;
+}
+
 //////////////////////////////////////////////////////////////////
 void st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
 {
@@ -24,53 +68,15 @@ void st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
     cursor->cursor_pos.sub_index = as_output_buffer ? 0 : 255;
     cursor->cursor_pos.segment_len = 1;
     cursor->cache_valid = false;
-    if (as_output_buffer) {
-        st_trie_payload_t *action = st_cursor_get_action(cursor);
-        if (cursor->cursor_pos.sub_index < action->completion_len) {
-            return;
-        }
-        // we have exceeded the length of the completion string
-        // advance to the next key that contains output
-        int backspaces = action->num_backspaces;
-        while (true) {
-            // move to next key in buffer
-            if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
-                // This is crazy, but it is theoretically possible that the
-                // entire buffer is full of backspaces such that no valid
-                // output key exists in the buffer!
-                // so we reset the buffer and set position to index 0; sub_index 0
-                st_key_buffer_reset(cursor->buffer);
-                cursor->cursor_pos.index = 0;
-                cursor->cursor_pos.sub_index = 0;
-                return;
-            }
-            cursor->cache_valid = false;
-            st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
-            // Below is an assert that should be made
-            // if (!keyaction) {
-            //     // We reached the end without finding the next output key
-            //     return false;
-            // }
-            if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
-                if (backspaces == 0) {
-                    // This is a real keypress and no more backspaces to consume
-                    cursor->cursor_pos.sub_index = 0;
-                    return;
-                }
-                // consume one backspace
-                --backspaces;
-                continue;
-            }
-            // Load payload of key that performed action
-            action = st_cursor_get_action(cursor);
-            if (backspaces < action->completion_len) {
-                // This action contains the next output key. Find it's sub_pos and return true
-                cursor->cursor_pos.sub_index = backspaces;
-                return;
-            }
-            backspaces -= action->completion_len - action->num_backspaces;
-        }
-        // current sub_index is valid, no need to advance
+    if (as_output_buffer && !cursor_advance_if_completion_exhausted(cursor)) {
+        // This is crazy, but it is theoretically possible that the
+        // entire buffer is full of backspaces such that no valid
+        // output key exists in the buffer!
+        // so we reset the buffer and set position to index 0; sub_index 0
+        st_key_buffer_reset(cursor->buffer);
+        cursor->cache_valid = false;
+        cursor->cursor_pos.index = 0;
+        cursor->cursor_pos.sub_index = 0;
     }
 }
 //////////////////////////////////////////////////////////////////

--- a/cursor.c
+++ b/cursor.c
@@ -17,6 +17,48 @@
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
 
 //////////////////////////////////////////////////////////////////
+bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
+{
+    st_trie_payload_t *action = st_cursor_get_action(cursor);
+    if (action->completion_len <= cursor->cursor_pos.sub_index) {
+        // we have exceeded the length of the completion string
+        // advance to the next key that contains output
+        int backspaces = action->num_backspaces;
+        while (true) {
+            // move to next key in buffer
+            if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
+                return false;
+            }
+            cursor->cache_valid = false;
+            st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
+            if (!keyaction) {
+                // We reached the end without finding the next output key
+                return false;
+            }
+            if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
+                if (backspaces == 0) {
+                    // This is a real keypress and no more backspaces to consume
+                    cursor->cursor_pos.sub_index = 0;
+                    return true;
+                }
+                // consume one backspace
+                --backspaces;
+                continue;
+            }
+            // Load payload of key that performed action
+            action = st_cursor_get_action(cursor);
+            if (backspaces < action->completion_len) {
+                // This action contains the next output key. Find it's sub_pos and return true
+                cursor->cursor_pos.sub_index = backspaces;
+                return true;
+            }
+            backspaces -= action->completion_len - action->num_backspaces;
+        }
+    }
+    // current sub_index is valid, no need to advance
+    return true;
+}
+//////////////////////////////////////////////////////////////////
 void st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
 {
     cursor->cursor_pos.index = history;
@@ -24,6 +66,9 @@ void st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
     cursor->cursor_pos.sub_index = as_output_buffer ? 0 : 255;
     cursor->cursor_pos.segment_len = 1;
     cursor->cache_valid = false;
+    if (as_output_buffer) {
+        cursor_advance_if_completion_exhausted(cursor);
+    }
 }
 //////////////////////////////////////////////////////////////////
 uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
@@ -70,9 +115,12 @@ bool st_cursor_next(st_cursor_t *cursor)
 {
     if (!cursor->cursor_pos.as_output_buffer) {
         ++cursor->cursor_pos.index;
-        ++cursor->cursor_pos.segment_len;
         cursor->cache_valid = false;
-        return cursor->cursor_pos.index < cursor->buffer->context_len;
+        if (cursor->cursor_pos.index < cursor->buffer->context_len) {
+            ++cursor->cursor_pos.segment_len;
+            return true;
+        }
+        return false;
     }
     // Continue processing if simulating output buffer
     st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
@@ -89,47 +137,15 @@ bool st_cursor_next(st_cursor_t *cursor)
         ++cursor->cursor_pos.segment_len;
         return true;
     }
-    st_trie_payload_t *action = st_cursor_get_action(cursor);
-    if (cursor->cursor_pos.sub_index < action->completion_len - 1) {
-        ++cursor->cursor_pos.sub_index;
+    // This is a key with an action and completion, increment the sub_index
+    // and advance to the next key in the key buffer if we exceeded the completion length
+    ++cursor->cursor_pos.sub_index;
+    if (cursor_advance_if_completion_exhausted(cursor)) {
         ++cursor->cursor_pos.segment_len;
         return true;
     }
-    // We have exhausted the key_action at the current buffer index
-    // check if we need to fast-forward over any backspaced chars
-    int backspaces = action->num_backspaces;
-    while (true) {
-        // move to next key in buffer
-        if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
-            return false;
-        }
-        cursor->cache_valid = false;
-        keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
-        if (!keyaction) {
-            // We reached the end without finding the next output key
-            return false;
-        }
-        if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
-            if (backspaces == 0) {
-                // This is a real keypress and no more backspaces to consume
-                cursor->cursor_pos.sub_index = 0;
-                ++cursor->cursor_pos.segment_len;
-                return true;
-            }
-            // consume one backspace
-            --backspaces;
-            continue;
-        }
-        // Load payload of key that performed action
-        action = st_cursor_get_action(cursor);
-        if (backspaces < action->completion_len) {
-            // This action contains the next output key. Find it's sub_pos and return true
-            cursor->cursor_pos.sub_index = backspaces;
-            ++cursor->cursor_pos.segment_len;
-            return true;
-        }
-        backspaces -= action->completion_len - action->num_backspaces;
-    }
+    // unable to advance due to hitting the end of the buffer.
+    return false;
 }
 //////////////////////////////////////////////////////////////////
 bool st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer)

--- a/cursor.c
+++ b/cursor.c
@@ -121,8 +121,11 @@ bool st_cursor_next(st_cursor_t *cursor)
         if (cursor->cursor_pos.index < cursor->buffer->context_len) {
             ++cursor->cursor_pos.segment_len;
             return true;
+        } else {
+            // leave `index` at the End position
+            cursor->cursor_pos.index = cursor->buffer->context_len;
+            return false;
         }
-        return false;
     }
     // Continue processing if simulating output buffer
     st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);

--- a/cursor.c
+++ b/cursor.c
@@ -16,7 +16,8 @@
 
 #define CDATA(L) pgm_read_byte(&trie->completions[L])
 
-bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
+//////////////////////////////////////////////////////////////////
+bool cursor_advance_to_valid_output(st_cursor_t *cursor)
 {
     st_trie_payload_t *action = st_cursor_get_action(cursor);
     if (cursor->cursor_pos.sub_index < action->completion_len) {
@@ -27,7 +28,8 @@ bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
     int backspaces = action->num_backspaces;
     while (true) {
         // move to next key in buffer
-        if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
+        ++cursor->cursor_pos.index;
+        if (st_cursor_at_end(cursor)) {
             return false;
         }
         cursor->cache_valid = false;
@@ -59,25 +61,26 @@ bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
     // current sub_index is valid, no need to advance
     return true;
 }
-
 //////////////////////////////////////////////////////////////////
-void st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
+bool st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
 {
     cursor->cursor_pos.index = history;
     cursor->cursor_pos.as_output_buffer = as_output_buffer;
     cursor->cursor_pos.sub_index = as_output_buffer ? 0 : 255;
     cursor->cursor_pos.segment_len = 1;
     cursor->cache_valid = false;
-    if (as_output_buffer && !cursor_advance_if_completion_exhausted(cursor)) {
+    if (as_output_buffer && !cursor_advance_to_valid_output(cursor)) {
         // This is crazy, but it is theoretically possible that the
         // entire buffer is full of backspaces such that no valid
         // output key exists in the buffer!
-        // so we reset the buffer and set position to index 0; sub_index 0
-        st_key_buffer_reset(cursor->buffer);
-        cursor->cache_valid = false;
-        cursor->cursor_pos.index = 0;
+        // Set the cursor_pos to the `end` position and return false
+        cursor->cursor_pos.index = cursor->buffer->context_len;
         cursor->cursor_pos.sub_index = 0;
+        return false;
     }
+    // TODO: add an assert that the buffer isn't empty, or maybe
+    // that should be done in the key_buffer code
+    return true;
 }
 //////////////////////////////////////////////////////////////////
 uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
@@ -123,19 +126,23 @@ st_trie_payload_t *st_cursor_get_action(st_cursor_t *cursor)
     return action;
 }
 //////////////////////////////////////////////////////////////////
+bool st_cursor_at_end(const st_cursor_t *cursor)
+{
+    return cursor->cursor_pos.index >= cursor->buffer->context_len;
+}
+//////////////////////////////////////////////////////////////////
 bool st_cursor_next(st_cursor_t *cursor)
 {
     if (!cursor->cursor_pos.as_output_buffer) {
         ++cursor->cursor_pos.index;
         cursor->cache_valid = false;
-        if (cursor->cursor_pos.index < cursor->buffer->context_len) {
-            ++cursor->cursor_pos.segment_len;
-            return true;
-        } else {
+        if (st_cursor_at_end(cursor)) {
             // leave `index` at the End position
             cursor->cursor_pos.index = cursor->buffer->context_len;
             return false;
         }
+        ++cursor->cursor_pos.segment_len;
+        return true;
     }
     // Continue processing if simulating output buffer
     st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
@@ -144,7 +151,8 @@ bool st_cursor_next(st_cursor_t *cursor)
     }
     if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
         // This is a normal keypress to consume
-        if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
+        ++cursor->cursor_pos.index;
+        if (st_cursor_at_end(cursor)) {
             return false;
         }
         cursor->cache_valid = false;
@@ -154,46 +162,12 @@ bool st_cursor_next(st_cursor_t *cursor)
     }
     // This is a key with an action and completion, increment the sub_index
     // and advance to the next key in the key buffer if we exceeded the completion length
-    st_trie_payload_t *action = st_cursor_get_action(cursor);
     ++cursor->cursor_pos.sub_index;
-    if (cursor->cursor_pos.sub_index >= action->completion_len) {
-        // we have exceeded the length of the completion string
-        // advance to the next key that contains output
-        int backspaces = action->num_backspaces;
-        while (true) {
-            // move to next key in buffer
-            if (++cursor->cursor_pos.index >= cursor->buffer->context_len) {
-                return false;
-            }
-            cursor->cache_valid = false;
-            st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
-            // Below is an assert that should be made
-            // if (!keyaction) {
-            //     // We reached the end without finding the next output key
-            //     return false;
-            // }
-            if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
-                if (backspaces == 0) {
-                    // This is a real keypress and no more backspaces to consume
-                    cursor->cursor_pos.sub_index = 0;
-                    break;
-                }
-                // consume one backspace
-                --backspaces;
-                continue;
-            }
-            // Load payload of key that performed action
-            action = st_cursor_get_action(cursor);
-            if (backspaces < action->completion_len) {
-                // This action contains the next output key. Find it's sub_pos and return true
-                cursor->cursor_pos.sub_index = backspaces;
-                break;
-            }
-            backspaces -= action->completion_len - action->num_backspaces;
-        }
+    if (cursor_advance_to_valid_output(cursor)) {
+        ++cursor->cursor_pos.segment_len;
+        return true;
     }
-    ++cursor->cursor_pos.segment_len;
-    return true;
+    return false;
 }
 //////////////////////////////////////////////////////////////////
 st_cursor_pos_t st_cursor_save(const st_cursor_t *cursor)
@@ -221,7 +195,7 @@ void st_cursor_print(st_cursor_t *cursor)
 // #ifdef SEQUENCE_TRANSFORM_LOG_GENERAL
     st_cursor_pos_t cursor_pos = st_cursor_save(cursor);
     uprintf("cursor: |");
-    while (cursor->cursor_pos.index < cursor->buffer->context_len) {
+    while (!st_cursor_at_end(cursor)) {
         uprintf("%c", st_keycode_to_char(st_cursor_get_keycode(cursor)));
         st_cursor_next(cursor);
     }

--- a/cursor.c
+++ b/cursor.c
@@ -88,6 +88,9 @@ uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
     }
 }
 //////////////////////////////////////////////////////////////////
+// DO NOT USE externally when cursor is initialized to act
+// as a virtual output. Behavior is not stable in the presence
+// of `st_cursor_get_keycode` in virtual output mode
 st_trie_payload_t *st_cursor_get_action(st_cursor_t *cursor)
 {
     st_trie_payload_t *action = &cursor->cached_action;
@@ -178,16 +181,6 @@ bool st_cursor_next(st_cursor_t *cursor)
     }
     ++cursor->cursor_pos.segment_len;
     return true;
-}
-//////////////////////////////////////////////////////////////////
-bool st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer)
-{
-    // invalidate cache
-    cursor->cache_valid = false;
-    cursor->cursor_pos.index = history;
-    cursor->cursor_pos.sub_index = 0;
-    cursor->cursor_pos.as_output_buffer = as_output_buffer;
-    return history < cursor->buffer->context_len;
 }
 //////////////////////////////////////////////////////////////////
 st_cursor_pos_t st_cursor_save(const st_cursor_t *cursor)

--- a/cursor.c
+++ b/cursor.c
@@ -31,10 +31,11 @@ bool cursor_advance_if_completion_exhausted(st_cursor_t *cursor)
             }
             cursor->cache_valid = false;
             st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
-            if (!keyaction) {
-                // We reached the end without finding the next output key
-                return false;
-            }
+            // Below is an assert that should be made
+            // if (!keyaction) {
+            //     // We reached the end without finding the next output key
+            //     return false;
+            // }
             if (keyaction->action_taken == ST_DEFAULT_KEY_ACTION) {
                 if (backspaces == 0) {
                     // This is a real keypress and no more backspaces to consume
@@ -134,8 +135,11 @@ bool st_cursor_next(st_cursor_t *cursor)
         }
         cursor->cache_valid = false;
         cursor->cursor_pos.sub_index = 0;
-        ++cursor->cursor_pos.segment_len;
-        return true;
+        if (cursor_advance_if_completion_exhausted(cursor)) {
+            ++cursor->cursor_pos.segment_len;
+            return true;
+        }
+        return false;
     }
     // This is a key with an action and completion, increment the sub_index
     // and advance to the next key in the key buffer if we exceeded the completion length

--- a/cursor.h
+++ b/cursor.h
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
-bool                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
+bool                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output);
 uint16_t                st_cursor_get_keycode(st_cursor_t *cursor);
 st_trie_payload_t       *st_cursor_get_action(st_cursor_t *cursor);
 bool                    st_cursor_at_end(const st_cursor_t *cursor);

--- a/cursor.h
+++ b/cursor.h
@@ -11,9 +11,10 @@
 //////////////////////////////////////////////////////////////////
 // Public API
 
-void                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
+bool                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
 uint16_t                st_cursor_get_keycode(st_cursor_t *cursor);
 st_trie_payload_t       *st_cursor_get_action(st_cursor_t *cursor);
+bool                    st_cursor_at_end(const st_cursor_t *cursor);
 bool                    st_cursor_next(st_cursor_t *cursor);
 st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
 void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);

--- a/cursor.h
+++ b/cursor.h
@@ -12,9 +12,9 @@
 // Public API
 
 void                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
-uint16_t                st_cursor_get_keycode(st_cursor_t *trie);
-st_trie_payload_t       *st_cursor_get_action(st_cursor_t *trie);
-bool                    st_cursor_next(st_cursor_t *trie);
+uint16_t                st_cursor_get_keycode(st_cursor_t *cursor);
+st_trie_payload_t       *st_cursor_get_action(st_cursor_t *cursor);
+bool                    st_cursor_next(st_cursor_t *cursor);
 bool                    st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
 st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
 void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);

--- a/cursor.h
+++ b/cursor.h
@@ -15,7 +15,6 @@ void                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t
 uint16_t                st_cursor_get_keycode(st_cursor_t *cursor);
 st_trie_payload_t       *st_cursor_get_action(st_cursor_t *cursor);
 bool                    st_cursor_next(st_cursor_t *cursor);
-bool                    st_cursor_move_to_history(st_cursor_t *cursor, int history, uint8_t as_output_buffer);
 st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
 void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);
 bool                    st_cursor_longer_than(const st_cursor_t *cursor, const st_cursor_pos_t *past_pos);

--- a/keybuffer.c
+++ b/keybuffer.c
@@ -31,16 +31,20 @@ uint16_t st_key_buffer_get_keycode(const st_key_buffer_t *buf, int index)
     const st_key_action_t *keyaction = st_key_buffer_get(buf, index);
     return (keyaction ? keyaction->keypressed : KC_NO);
 }
-//////////////////////////////////////////////////////////////////
+/**
+ * @brief Gets an st_key_action_t from the `index` position in the key_buffer
+ * @param buf st_key_buffer* receives the st_key_action
+ * @param index int index starting with 0 as the most recent keypress and increasing for older keypresses
+ *
+ * @return true if the index points to a valid key_action in the buffer
+ * @return false if index is out-of-bounds
+ */
 st_key_action_t *st_key_buffer_get(const st_key_buffer_t *buf, int index)
 {
     if (index < 0) {
         index += buf->context_len;
     }
     if (index >= buf->context_len || index < 0) {
-#ifdef SEQUENCE_TRANSFORM_LOG_GENERAL
-        uprintf("Accessing index (%d) outside valid range (-%d, %d)!\n", index, buf->context_len, buf->context_len);
-#endif
         return NULL;
     }
     int buf_index = buf->cur_pos - index;

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -248,7 +248,8 @@ void log_rule(st_trie_search_result_t *res, char *completion_str) {
     const st_trie_payload_t *rule_action = st_cursor_get_action(&trie_cursor);
     const bool is_repeat = rule_action->func_code == 1;
     const int prev_seq_len = res->trie_match.seq_match_pos.segment_len - 1;
-    st_cursor_move_to_history(&trie_cursor, 1, res->trie_match.seq_match_pos.as_output_buffer);
+    // The cursor can't be empty here even if it is as output, because we know it matched a rule
+    st_cursor_init(&trie_cursor, 1, res->trie_match.seq_match_pos.as_output);
     st_cursor_push_to_stack(&trie_cursor, prev_seq_len);
     char seq_str[SEQUENCE_MAX_LENGTH + 1];
     st_key_stack_to_str(trie.key_stack, seq_str);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -100,6 +100,7 @@ static st_cursor_t trie_cursor = {
 #ifdef ST_TESTER
 st_trie_t       *st_get_trie(void) { return &trie; }
 st_key_buffer_t *st_get_key_buffer(void) { return &key_buffer; }
+st_cursor_t *st_get_cursor(void) { return &trie_cursor; }
 #endif
 
 /**

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -395,9 +395,12 @@ void st_handle_backspace() {
 /**
  * @brief Fills the provided buffer with up to `count` characters from the virtual output
  *
- * @return the number of characters written to the buffer
+ * @param str char* to write the virtual output to. Will be null terminated.
+ * @param history int 0 for the current output. N for the output N keypresses ago.
+ * @param count int representing the number of characters requested. str must be hold `count + 1` chars
+ * @return the number of characters written to the str not including the null terminator
  */
-uint8_t st_get_virtual_output(char *buf, uint8_t count)
+uint8_t st_get_virtual_output(char *str, uint8_t count)
 {
     st_cursor_init(&trie_cursor, 0, true);
     int i = 0;
@@ -406,9 +409,9 @@ uint8_t st_get_virtual_output(char *buf, uint8_t count)
         if (!keycode) {
             break;
         }
-        buf[i] = st_keycode_to_char(keycode);
+        str[i] = st_keycode_to_char(keycode);
     }
-    buf[i] = '\0';
+    str[i] = '\0';
     return i;
 }
 

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -376,8 +376,7 @@ void st_handle_backspace() {
     // If previous action used backspaces, restore the deleted output from earlier actions
     if (resend_count > 0) {
         // reinitialize cursor as output cursor one keystroke before the previous action
-        st_cursor_init(&trie_cursor, 1, true);
-        if (st_cursor_push_to_stack(&trie_cursor, resend_count)) {
+        if (st_cursor_init(&trie_cursor, 1, true) && st_cursor_push_to_stack(&trie_cursor, resend_count)) {
             // Send backspaces now that we know we can do the full undo
             st_multi_tap(KC_BSPC, backspaces_needed_count);
             // Send saved keys in original order
@@ -403,7 +402,10 @@ void st_handle_backspace() {
  */
 uint8_t st_get_virtual_output(char *str, uint8_t count)
 {
-    st_cursor_init(&trie_cursor, 0, true);
+    if (!st_cursor_init(&trie_cursor, 0, true)) {
+        str[0] = '\0';
+        return 0;
+    }
     int i = 0;
     for (; i < count; ++i, st_cursor_next(&trie_cursor)) {
         const uint16_t keycode = st_cursor_get_keycode(&trie_cursor);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -346,7 +346,8 @@ void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res) {
 //////////////////////////////////////////////////////////////////////////////////////////
 #ifndef SEQUENCE_TRANSFORM_DISABLE_ENHANCED_BACKSPACE
 void st_handle_backspace() {
-    st_cursor_init(&trie_cursor, 0, true);
+    // initialize cursor as input cursor, so that `st_cursor_get_action` is stable
+    st_cursor_init(&trie_cursor, 0, false);
     const st_trie_payload_t *action = st_cursor_get_action(&trie_cursor);
     if (action->completion_index == ST_DEFAULT_KEY_ACTION) {
         // previous key-press didn't trigger a rule action. One total backspace required
@@ -373,7 +374,8 @@ void st_handle_backspace() {
 #endif
     // If previous action used backspaces, restore the deleted output from earlier actions
     if (resend_count > 0) {
-        st_cursor_move_to_history(&trie_cursor, 1, true);
+        // reinitialize cursor as output cursor one keystroke before the previous action
+        st_cursor_init(&trie_cursor, 1, true);
         if (st_cursor_push_to_stack(&trie_cursor, resend_count)) {
             // Send backspaces now that we know we can do the full undo
             st_multi_tap(KC_BSPC, backspaces_needed_count);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -399,14 +399,16 @@ void st_handle_backspace() {
 uint8_t st_get_virtual_output(char *buf, uint8_t count)
 {
     st_cursor_init(&trie_cursor, 0, true);
-    for (int i = 0; i < count; ++i, st_cursor_next(&trie_cursor)) {
+    int i = 0;
+    for (; i < count; ++i, st_cursor_next(&trie_cursor)) {
         const uint16_t keycode = st_cursor_get_keycode(&trie_cursor);
         if (!keycode) {
-            return i;
+            break;
         }
         buf[i] = st_keycode_to_char(keycode);
     }
-    return count;
+    buf[i] = '\0';
+    return i;
 }
 
 /**

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -44,4 +44,5 @@ uint8_t st_get_virtual_output(char *buf, uint8_t count);
 #ifdef ST_TESTER
 st_trie_t       *st_get_trie(void);
 st_key_buffer_t *st_get_key_buffer(void);
+st_cursor_t *st_get_cursor(void);
 #endif

--- a/tester/Makefile
+++ b/tester/Makefile
@@ -45,6 +45,7 @@ _OBJ = tester.o \
 	test_ascii_string.o \
 	test_perform.o \
 	test_virtual_output.o \
+	test_cursor.o \
 	test_backspace.o \
 	test_find_rule.o \
 	qmk_wrapper.o \

--- a/tester/test_all_rules.c
+++ b/tester/test_all_rules.c
@@ -18,7 +18,7 @@ static st_test_info_t rule_tests[] = {
     { test_virtual_output,  "st_virtual_output",    { false, 0 } },
     { test_cursor,          "st_cursor",            { false, 0 } },
     { test_backspace,       "st_handle_backspace",  { false, 0 } },
-    // { test_find_rule,       "st_find_missed_rule",  { false, 0 } },
+    { test_find_rule,       "st_find_missed_rule",  { false, 0 } },
     { 0,                    0,                      { false, 0 } }
 };
 

--- a/tester/test_all_rules.c
+++ b/tester/test_all_rules.c
@@ -18,7 +18,7 @@ static st_test_info_t rule_tests[] = {
     { test_virtual_output,  "st_virtual_output",    { false, 0 } },
     { test_cursor,          "st_cursor",            { false, 0 } },
     { test_backspace,       "st_handle_backspace",  { false, 0 } },
-    { test_find_rule,       "st_find_missed_rule",  { false, 0 } },
+    // { test_find_rule,       "st_find_missed_rule",  { false, 0 } },
     { 0,                    0,                      { false, 0 } }
 };
 

--- a/tester/test_all_rules.c
+++ b/tester/test_all_rules.c
@@ -16,6 +16,7 @@ static const char *test_fail_str = "[\033[0;31mfail\033[0m]";
 static st_test_info_t rule_tests[] = {
     { test_perform,         "st_perform",           { false, 0 } },
     { test_virtual_output,  "st_virtual_output",    { false, 0 } },
+    { test_cursor,          "st_cursor",            { false, 0 } },
     { test_backspace,       "st_handle_backspace",  { false, 0 } },
     { test_find_rule,       "st_find_missed_rule",  { false, 0 } },
     { 0,                    0,                      { false, 0 } }

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -15,10 +15,6 @@ void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
 {
     static char message[512];
     res->message = message;
-    // sim_st_perform was run in a previous test
-    char *sim_output = sim_output_get(false);
-    const int sim_len = sim_output_get_size();
-    char virtual_output[256];
     st_cursor_t *cursor = st_get_cursor();
     st_cursor_init(cursor, 0, false);
     for (int i = 0; i < 200; ++i) {

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include "qmk_wrapper.h"
+#include "keybuffer.h"
+#include "key_stack.h"
+#include "trie.h"
+#include "cursor.h"
+#include "sequence_transform.h"
+#include "sequence_transform_data.h"
+#include "sequence_transform_test.h"
+#include "sim_output_buffer.h"
+#include "tester.h"
+
+//////////////////////////////////////////////////////////////////////
+void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
+{
+    static char message[512];
+    res->message = message;
+    // sim_st_perform was run in a previous test
+    char *sim_output = sim_output_get(false);
+    const int sim_len = sim_output_get_size();
+    char virtual_output[256];
+    st_cursor_t *cursor = st_get_cursor();
+    st_cursor_init(cursor, 0, false);
+    for (int i = 0; i < 200; ++i) {
+        st_cursor_next(cursor);
+    }
+    res->pass = cursor->cursor_pos.index == cursor->buffer->context_len;
+    if (!res->pass) {
+        snprintf(message, sizeof(message), "input cursor didn't stop at end: cursor index %d; context_len: %d",
+                    cursor->cursor_pos.index,
+                    cursor->buffer->context_len);
+    }
+    st_cursor_init(cursor, 0, true);
+    for (int i = 0; i < 200; ++i) {
+        st_cursor_next(cursor);
+    }
+    res->pass = cursor->cursor_pos.index == cursor->buffer->context_len;
+    if (res->pass) {
+        snprintf(message, sizeof(message), "OK!");
+    } else {
+        snprintf(message, sizeof(message), "output cursor didn't stop at end: cursor index %d; context_len: %d",
+                    cursor->cursor_pos.index,
+                    cursor->buffer->context_len);
+    }
+}

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -26,9 +26,10 @@ void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
                     cursor->cursor_pos.index,
                     cursor->buffer->context_len);
     }
-    st_cursor_init(cursor, 0, true);
-    for (int i = 0; i < 200; ++i) {
-        st_cursor_next(cursor);
+    if (st_cursor_init(cursor, 0, true)) {
+        for (int i = 0; i < 200; ++i) {
+            st_cursor_next(cursor);
+        }
     }
     res->pass = cursor->cursor_pos.index == cursor->buffer->context_len;
     if (res->pass) {

--- a/tester/tester.h
+++ b/tester/tester.h
@@ -32,6 +32,7 @@ void    sim_st_find_missed_rule(const uint16_t *keycodes);
 //      Rule tests
 void    test_perform(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res);
+void    test_cursor(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_backspace(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_find_rule(const st_test_rule_t *rule, st_test_result_t *res);
 int     test_rule(const st_test_rule_t *rule, bool print_all);

--- a/tester/tester.vcxproj
+++ b/tester/tester.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="test_all_rules.c" />
     <ClCompile Include="test_ascii_string.c" />
     <ClCompile Include="test_backspace.c" />
+    <ClCompile Include="test_cursor.c" />
     <ClCompile Include="test_find_rule.c" />
     <ClCompile Include="test_perform.c" />
     <ClCompile Include="test_virtual_output.c" />

--- a/trie.c
+++ b/trie.c
@@ -30,12 +30,9 @@ bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res)
     st_cursor_init(cursor, 0, false);
     st_find_longest_chain(cursor, &res->trie_match, 0);
 #ifdef SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER
-    st_cursor_init(cursor, 0, true);
-
-#ifdef SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS
-    st_cursor_print(cursor);
-#endif
-    st_find_longest_chain(cursor, &res->trie_match, 0);
+    if (st_cursor_init(cursor, 0, true)) {
+        st_find_longest_chain(cursor, &res->trie_match, 0);
+    }
 #endif
     if (res->trie_match.seq_match_pos.segment_len > 0) {
         st_get_payload_from_match_index(cursor->trie, &res->trie_payload, res->trie_match.trie_match_index);

--- a/trie.h
+++ b/trie.h
@@ -24,7 +24,7 @@ typedef struct
     int     index;                // buffer index of cursor position
     int     sub_index;            // Sub-position within the current buffer position
     int     segment_len;        // Number of elements traversed
-    uint8_t as_output_buffer;   // True if buffer traversing the simulated output
+    uint8_t as_output;   // True if buffer traversing the simulated output
 } st_cursor_pos_t;
 
 typedef struct
@@ -40,7 +40,7 @@ typedef struct
 
 typedef struct
 {
-    st_key_buffer_t * const       buffer;           // input buffer this cursor traverses
+    st_key_buffer_t const * const buffer;           // input buffer this cursor traverses
     st_trie_t const * const       trie;             // trie used for traversing virtual output buffer
     st_cursor_pos_t               cursor_pos;       // Contains all position info for the cursor
     st_trie_payload_t             cached_action;

--- a/trie.h
+++ b/trie.h
@@ -40,7 +40,7 @@ typedef struct
 
 typedef struct
 {
-    st_key_buffer_t const * const buffer;           // input buffer this cursor traverses
+    st_key_buffer_t * const       buffer;           // input buffer this cursor traverses
     st_trie_t const * const       trie;             // trie used for traversing virtual output buffer
     st_cursor_pos_t               cursor_pos;       // Contains all position info for the cursor
     st_trie_payload_t             cached_action;


### PR DESCRIPTION
The cursor next and cursor init made an implicit assumption that the completion_str of an action was not empty. That assumption is invalid in backspace only rules. This PR removes that assumption and always verifies that the cursor ends on a spot with a valid key to output.