### PR TITLE
ST rules.mk

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,7 @@
+# This file should be included in user layout's rules.mk file
+LIB_SRC += sequence_transform/sequence_transform.c
+LIB_SRC += sequence_transform/utils.c
+LIB_SRC += sequence_transform/trie.c
+LIB_SRC += sequence_transform/keybuffer.c
+LIB_SRC += sequence_transform/key_stack.c
+LIB_SRC += sequence_transform/cursor.c


### PR DESCRIPTION
Added sequence transform `rules.mk` that should be included from user layout's `rules.mk`, instead of including our src files directly.
This file should be updated when we add/remove .c files to the lib.

Example of how to use it. Add this line to the bottom of your layout's rules.mk, adjusting the path.
```
include keyboards/moonlander/keymaps/kamih/sequence_transform/rules.mk
```