### PR TITLE
Rule search fixes

### DIFF
--- a/key_stack.c
+++ b/key_stack.c
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "key_stack.h"
 #include "utils.h"
 

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -291,30 +291,26 @@ void st_find_missed_rule(void)
     // find buffer index for the space before the last word,
     // first skipping past trailing spaces
     // (in case a rule has spaces at the end of its completion)
-    int start_index = 0;
-    while (start_index < key_buffer.context_len &&
-           KEY_AT(start_index) == KC_SPACE) {
-        ++start_index;
+    int word_start_idx = 0;
+    while (word_start_idx < key_buffer.context_len &&
+           KEY_AT(word_start_idx) == KC_SPACE) {
+        ++word_start_idx;
     }
     // if we reached the end of the buffer here,
     // it means it's filled wish spaces, so bail.
-    if (start_index == key_buffer.context_len) {        
+    if (word_start_idx == key_buffer.context_len) {        
         return;
     }
     // we've skipped trailing spaces, so now find the next space
-    while (start_index < key_buffer.context_len &&
-           KEY_AT(start_index) != KC_SPACE) {
-        ++start_index;
+    while (word_start_idx < key_buffer.context_len &&
+           KEY_AT(word_start_idx) != KC_SPACE) {
+        ++word_start_idx;
     }
-    //uprintf("start_index: %d\n", start_index);
-    const int len_to_last_space = key_buffer.context_len - start_index;
-    const int search_len_start = st_clamp(len_to_last_space,
-                                          1,
-                                          key_buffer.context_len - 1);
+    //uprintf("word_start_idx: %d\n", word_start_idx);
     st_trie_rule_t result;
     result.sequence = sequence_str;
     result.transform = transform_str;
-    if (st_trie_get_rule(&trie, &key_buffer, search_len_start, &result)) {
+    if (st_trie_do_rule_searches(&trie, &key_buffer, word_start_idx, &result)) {
         sequence_transform_on_missed_rule_user(&result);
     }
 #endif

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -286,17 +286,26 @@ void st_find_missed_rule(void)
 #ifdef SEQUENCE_TRANSFORM_MISSED_RULES
     char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
     char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
-    // find buffer index for last space
-    int last_space_index = 0;
-    while (last_space_index < key_buffer.context_len &&
-           KEY_AT(last_space_index) != KC_SPACE) {
-        ++last_space_index;
+    // find buffer index for the space before the last word,
+    // first skipping past trailing spaces
+    // (in case a rule has spaces at the end of its completion)
+    int start_index = 0;
+    while (start_index < key_buffer.context_len &&
+           KEY_AT(start_index) == KC_SPACE) {
+        ++start_index;
     }
-    if (last_space_index == 0) {
+    // if we reached the end of the buffer here,
+    // it means it's filled wish spaces, so bail.
+    if (start_index == key_buffer.context_len) {        
         return;
     }
-    //uprintf("last_space_index: %d\n", last_space_index);
-    const int len_to_last_space = key_buffer.context_len - last_space_index;
+    // we've skipped trailing spaces, so now find the next space
+    while (start_index < key_buffer.context_len &&
+           KEY_AT(start_index) != KC_SPACE) {
+        ++start_index;
+    }
+    //uprintf("start_index: %d\n", start_index);
+    const int len_to_last_space = key_buffer.context_len - start_index;
     const int search_len_start = st_clamp(len_to_last_space,
                                           1,
                                           key_buffer.context_len - 1);

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -286,7 +286,6 @@ void st_find_missed_rule(void)
 #ifdef SEQUENCE_TRANSFORM_MISSED_RULES
     char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
     char transform_str[TRANSFORM_MAX_LEN + 1] = {0};
-    static int search_len_from_space = 0;
     // find buffer index for last space
     int last_space_index = 0;
     while (last_space_index < key_buffer.context_len &&
@@ -294,24 +293,18 @@ void st_find_missed_rule(void)
         ++last_space_index;
     }
     if (last_space_index == 0) {
-        //uprintf("space at top, resetting search_len_from_space\n");
-        search_len_from_space = 0;
         return;
     }
-    //uprintf("last_space_index: %d, search_len_from_space: %d\n",
-    //        last_space_index, search_len_from_space);
+    //uprintf("last_space_index: %d\n", last_space_index);
     const int len_to_last_space = key_buffer.context_len - last_space_index;
-    const int search_len_start = st_clamp(len_to_last_space + search_len_from_space,
+    const int search_len_start = st_clamp(len_to_last_space,
                                           1,
                                           key_buffer.context_len - 1);
     st_trie_rule_t result;
     result.sequence = sequence_str;
     result.transform = transform_str;
-    const int new_len = st_trie_get_rule(&trie, &key_buffer, search_len_start, &result);
-    if (new_len != search_len_start) {
+    if (st_trie_get_rule(&trie, &key_buffer, search_len_start, &result)) {
         sequence_transform_on_missed_rule_user(&result);
-        // Next time, start searching from after completion
-        search_len_from_space = new_len - len_to_last_space;
     }
 #endif
 }

--- a/trie.h
+++ b/trie.h
@@ -67,7 +67,7 @@ typedef struct
 } st_trie_search_result_t;
 
 bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res);
-bool st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, int search_len_start, st_trie_rule_t *rule);
+bool st_trie_do_rule_searches(st_trie_t *trie, const st_key_buffer_t *key_buffer, int word_start_idx, st_trie_rule_t *rule);
 
 //////////////////////////////////////////////////////////////////
 // Internal
@@ -76,15 +76,15 @@ typedef struct
 {
     st_trie_t               *trie;                  // trie to search
     const st_key_buffer_t   *key_buffer;            // search buffer
-    int                     search_len;             // amount of buffer (from oldest key) to use when searching
+    int                     search_end_ridx;        // reverse index to end of search window
     int                     skip_levels;	        // number of trie levels to 'skip' when searching
-    int                     max_transform_len;      // keeps track of best result
+    int                     max_transform_end_ridx; // reverse index to end of best completed word
     st_trie_rule_t          *result;                // pointer to result to be filled with best match
 } st_trie_search_t;
 
 void st_get_payload_from_match_index(const st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);
 void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index);
-bool st_find_rule(st_trie_search_t *search, uint16_t offset);
+bool st_trie_rule_search(st_trie_search_t *search, uint16_t offset);
 bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, uint16_t offset);
 void st_completion_to_str(const st_trie_t *trie, const st_trie_payload_t *payload, char *str);
 bool st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search);

--- a/trie.h
+++ b/trie.h
@@ -67,7 +67,7 @@ typedef struct
 } st_trie_search_result_t;
 
 bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res);
-int st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, int search_len_start, st_trie_rule_t *res);
+bool st_trie_get_rule(st_trie_t *trie, const st_key_buffer_t *key_buffer, int search_len_start, st_trie_rule_t *rule);
 
 //////////////////////////////////////////////////////////////////
 // Internal
@@ -85,6 +85,6 @@ typedef struct
 void st_get_payload_from_match_index(const st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);
 void st_get_payload_from_code(st_trie_payload_t *payload, uint16_t code, uint16_t completion_index);
 bool st_find_rule(st_trie_search_t *search, uint16_t offset);
-void st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search);
 bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, uint16_t offset);
-void st_completion_to_str(const st_trie_t *trie, st_trie_payload_t *payload, char *buf);
+void st_completion_to_str(const st_trie_t *trie, const st_trie_payload_t *payload, char *str);
+bool st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search);

--- a/trie.h
+++ b/trie.h
@@ -78,7 +78,6 @@ typedef struct
     const st_key_buffer_t   *key_buffer;            // search buffer
     int                     search_end_ridx;        // reverse index to end of search window
     int                     skip_levels;	        // number of trie levels to 'skip' when searching
-    int                     max_transform_end_ridx; // reverse index to end of best completed word
     st_trie_rule_t          *result;                // pointer to result to be filled with best match
 } st_trie_search_t;
 

--- a/utils.c
+++ b/utils.c
@@ -51,10 +51,16 @@ static const char shifted_keycode_to_ascii_lut[53] PROGMEM = {
     '?'
 };
 
+//////////////////////////////////////////////////////////////////////
+bool st_is_seq_token_keycode(uint16_t key)
+{
+    return (key >= SPECIAL_KEY_TRIECODE_0 &&
+            key < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT);
+}
 ////////////////////////////////////////////////////////////////////////////////
 char st_keycode_to_char(uint16_t keycode)
 {
-    if (keycode >= SPECIAL_KEY_TRIECODE_0 && keycode < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT) {
+    if (st_is_seq_token_keycode(keycode)) {
 		return st_seq_tokens_ascii[keycode - SPECIAL_KEY_TRIECODE_0];
     } else if (keycode == KC_SPACE) {
         return st_wordbreak_ascii;

--- a/utils.h
+++ b/utils.h
@@ -13,6 +13,7 @@
 
 #define IS_ALPHA_KEYCODE(code) ((code) >= KC_A && (code) <= KC_Z)
 
+bool        st_is_seq_token_keycode(uint16_t key);
 uint16_t    st_char_to_keycode(char c);
 char        st_keycode_to_char(uint16_t keycode);
 void        st_multi_tap(uint16_t keycode, int count);


### PR DESCRIPTION
This PR fixes a couple of issues with rule search:

- False positive matches were sometimes being reported. The trie traversal stack string is now always compared to the search buffer to make sure the rule sequence actually matches.
- Rules can now only be chosen if its completion string reaches the end of the current search buffer.
- Search is now always started from the space before the last word, even if we found a match on an earlier key press. This allows us to find `s@ -> something` when we reach the end of the word, even if we have a `so* -> some` rule.
- Search can now find rules that have spaces at the end of their completion strings.
- Early exit in match check if rule is `untestable` (ie. sequence contains unexpanded seq tokens and the rule contains backspaces).
