### PR TITLE
Sequence tokens regex enhancement

### DIFF
--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -306,7 +306,9 @@ def complete_trie(trie: Dict[str, Any], wordbreak_char: str) -> set[str]:
 
 ###############################################################################
 def generate_matches(pattern) -> list[tuple[str, str]]:
-    square_brackets_group = re.findall(r"\[(\w+)]", pattern)
+    valid_tokens = f"[\w{MAGIC_CHARS}]"
+
+    square_brackets_group = re.findall(fr"\[({valid_tokens}+)]", pattern)
     if square_brackets_group:
         match = square_brackets_group[0]
 
@@ -316,13 +318,13 @@ def generate_matches(pattern) -> list[tuple[str, str]]:
         ))
 
     patterns = []
-    groups = re.findall(r"\((?:\w\|?)+\)\??", pattern)
+    groups = re.findall(fr"\((?:{valid_tokens}\|?)+\)\??", pattern)
 
     if not groups:
         return [("", pattern)]
 
     match = groups[0]
-    elements = re.findall("\w+", match)
+    elements = re.findall(f"{valid_tokens}+", match)
 
     patterns.extend([
         (element, pattern.replace(match, element))

--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -306,7 +306,7 @@ def complete_trie(trie: Dict[str, Any], wordbreak_char: str) -> set[str]:
 
 ###############################################################################
 def generate_matches(pattern) -> list[tuple[str, str]]:
-    valid_tokens = f"[\w{MAGIC_CHARS}]"
+    valid_tokens = f"[\w{MAGIC_CHARS}{WORDBREAK_CHAR}]"
 
     square_brackets_group = re.findall(fr"\[({valid_tokens}+)]", pattern)
     if square_brackets_group:


### PR DESCRIPTION
Small pr to allow user to use sequence tokens inside of regex groups

For example: `(★l|l★)` was not a valid group before, but it is with this pr
It uses `[\w{MAGIC_CHARS}]`(it was just `\w` before) regex group to capture regex groups from the dictionary, so its pretty much safe

- Also allowed wordbreak char inside of regex groups, cant figure any use case for that, but there is no actual reason to limit that