### PR TITLE
Tester warnings

### DIFF
--- a/tester/Makefile
+++ b/tester/Makefile
@@ -5,7 +5,7 @@ QMKPATH		?= /home/qmk/qmk_firmware
 ST_GEN_PY	?= ../generator/sequence_transform_data.py
 ST_DICT 	?= ../../sequence_transform_dict.txt
 ST_CONFIG	?= ../../sequence_transform_config.json
-ST_GEN_IN 	:= $(ST_CONFIG) $(ST_DICT)
+ST_GEN_IN 	:= $(ST_CONFIG) $(ST_DICT) $(ST_GEN_PY)
 
 LIB_DIR			:= ../
 TESTER_DIR		:= ./

--- a/tester/Makefile
+++ b/tester/Makefile
@@ -1,19 +1,29 @@
-ifeq ($(QMKPATH),)
-  $(error Please set the QMKPATH env var to your qmk_firmware directory)
-endif
+CC			:= gcc
+PYTHON		:= python3
+ODIR		:= build
+QMKPATH		?= /home/qmk/qmk_firmware
+ST_GEN_PY	?= ../generator/sequence_transform_data.py
+ST_DICT 	?= ../../sequence_transform_dict.txt
+ST_CONFIG	?= ../../sequence_transform_config.json
+ST_GEN_IN 	:= $(ST_CONFIG) $(ST_DICT)
 
-CC = gcc
+LIB_DIR			:= ../
+TESTER_DIR		:= ./
+LIB_SOURCES		:= $(wildcard $(LIB_DIR)/*.c)
+LIB_OBJECTS		:= $(LIB_SOURCES:$(LIB_DIR)/%.c=$(ODIR)/%.o)
+TESTER_SOURCES	:= $(wildcard $(TESTER_DIR)/*.c) 
+TESTER_OBJECTS	:= $(TESTER_SOURCES:$(TESTER_DIR)/%.c=$(ODIR)/%.o) $(LIB_OBJECTS)
+DEPENDS			:= $(TESTER_OBJECTS:%.o=%.d)
 
-ODIR = build
-
-vpath %.c  ./ ../
+vpath %.c  $(LIB_DIR) $(TESTER_DIR)
 
 OSFLAG :=
 ifeq ($(OS),Windows_NT)
 	OSFLAG += -D WIN32
 endif
 
-CFLAGS = -I. \
+CFLAGS := -Werror \
+	-I. \
 	-I$(QMKPATH)/platforms \
 	-I$(QMKPATH)/quantum \
 	-I$(QMKPATH)/quantum/sequencer \
@@ -27,48 +37,31 @@ CFLAGS = -I. \
 	-D_CONSOLE \
 	$(OSFLAG)
 
-DEPS = tester.h \
-	tester_utils.h \
-	sim_output_buffer.h \
-	../qmk_wrapper.h \
-	../keybuffer.h \
-	../key_stack.h \
-	../trie.h \
-	../cursor.h \
-	../utils.h \
-	../sequence_transform.h \
-	../sequence_transform_data.h \
+ST_GEN_OUT := ../sequence_transform_data.h \
 	../sequence_transform_test.h
 
-_OBJ = tester.o \
-	test_all_rules.o \
-	test_ascii_string.o \
-	test_perform.o \
-	test_virtual_output.o \
-	test_backspace.o \
-	test_find_rule.o \
-	qmk_wrapper.o \
-	tester_utils.o \
-	sim_output_buffer.o \
-	keybuffer.o \
-	key_stack.o \
-	trie.o \
-	cursor.o \
-	utils.o \
-	sequence_transform.o
+all: gen tester
 
-OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
+$(ST_GEN_OUT): $(ST_GEN_IN)
+	@echo Running generator
+	$(PYTHON) $(ST_GEN_PY) -c $(ST_CONFIG)
 
-$(ODIR)/%.o: %.c $(DEPS)
-	@echo Compiling $<
-	@mkdir -p $(ODIR)
-	@$(CC) -c -o $@ $< $(CFLAGS)
+gen: $(ST_GEN_OUT) 
 
-tester: $(OBJ)
+tester: $(TESTER_OBJECTS)
 	@$(CC) -o $@ $^ $(CFLAGS)
 	@echo "Build successful!"
+
+-include $(DEPENDS)
+
+$(ODIR)/%.o: %.c | $(ODIR)
+	@echo Compiling $<
+	@$(CC) -MMD -c -o $@ $< $(CFLAGS)
+
+$(ODIR): 
+	@mkdir -p $@
 
 .PHONY: clean
 
 clean:
-	rm -f $(ODIR)/*.o
+	rm -f $(ODIR)/*.o $(ODIR)/*.d

--- a/tester/sim_output_buffer.c
+++ b/tester/sim_output_buffer.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include "sim_output_buffer.h"
 #include "utils.h"
+#include "tester_utils.h"
 
 //////////////////////////////////////////////////////////////////
 #define SIM_OUTPUT_BUFFER_CAPACITY 256
@@ -35,9 +36,7 @@ char *sim_output_get(bool trim_spaces)
     if (!trim_spaces) {
         return sim_output_buffer;
     }
-    char *output = sim_output_buffer;
-    while (*output++ == ' ');
-    return --output;
+    return ltrim_str(sim_output_buffer);
 }
 //////////////////////////////////////////////////////////////////
 int sim_output_get_size()

--- a/tester/test_all_rules.c
+++ b/tester/test_all_rules.c
@@ -27,21 +27,38 @@ static st_test_info_t rule_tests[] = {
 };
 
 //////////////////////////////////////////////////////////////////////
-int test_rule(const st_test_rule_t *rule, bool print_all)
+void print_available_tests(void)
+{
+    for (int i = 0; rule_tests[i].func; ++i) {
+        printf("  #%d %s\n", i+1, rule_tests[i].name);
+    }
+}
+//////////////////////////////////////////////////////////////////////
+int test_rule(const st_test_rule_t *rule,
+              bool *tests,
+              bool print_all,
+              int *warns)
 {
     // Call all the tests and gather results
     bool all_pass = true;
     bool print = print_all;
     for (int i = 0; rule_tests[i].func; ++i) {
+        if (!tests[i]) {
+            continue;
+        }
+        // setup default result
         st_test_result_t *res = &rule_tests[i].res;
         res->code = TEST_OK;
         res->message[0] = 0;
+        // call test
         rule_tests[i].func(rule, res);
+        // examine result
         if (res->code == TEST_FAIL) {
             all_pass = false;
-        }
-        if (res->code != TEST_OK) {
             print = true;
+        } else if (res->code == TEST_WARN) {
+            print = true;
+            *warns = *warns + 1;
         }
     }    
     if (!print) {
@@ -52,6 +69,9 @@ int test_rule(const st_test_rule_t *rule, bool print_all)
     keycodes_to_utf8_str(rule->seq_keycodes, seq_str);
     printf("[rule] %s ⇒ %s\n", seq_str, rule->transform_str);
     for (int i = 0; rule_tests[i].func; ++i) {
+        if (!tests[i]) {
+            continue;
+        }
         const st_test_info_t *test = &rule_tests[i];
         const bool pass = test->res.code == TEST_OK;
         if (print_all || !pass) {
@@ -67,15 +87,42 @@ int test_rule(const st_test_rule_t *rule, bool print_all)
 //////////////////////////////////////////////////////////////////////
 int test_all_rules(const st_test_options_t *options)
 {
-    int rules = 0, pass = 0;
-    for (; st_test_rules[rules].transform_str; ++rules) {
-        pass += test_rule(&st_test_rules[rules], options->print_all);
+    // Determine which tests should be run
+    const int total_tests = sizeof(rule_tests) / sizeof(st_test_info_t) - 1;
+    bool      tests[total_tests];
+    const int str_len = options->tests ? strlen(options->tests) : 0;
+    for (int i = 0; rule_tests[i].func; ++i) {
+        tests[i] = true;
+        if (str_len && (i >= str_len || options->tests[i] == '0')) {
+            tests[i] = false;
+        }
     }
-    const int fail = rules - pass;
+    // Apply tests to each rule
+    int rules = 0, pass = 0, warns = 0;
+    for (; st_test_rules[rules].transform_str; ++rules) {
+        pass += test_rule(&st_test_rules[rules],
+                          tests,
+                          options->print_all,
+                          &warns);
+    }    
+    // Show tests performed and stats
+    printf("--- TEST SUMMARY ---\n");
+    printf("Rules tested: %d\n", rules);
+    const int fail = rules - pass;    
     if (!fail) {
-        printf("\n[\033[0;32mAll %d tests passed!\033[0m]\n", rules);
+        printf("\033[0;32mAll tests passed!\033[0m\n");
     } else {
-        printf("\n[\033[0;31m%d/%d tests failed!\033[0m]\n", fail, rules);
+        printf("\033[0;31m%d tests failed!\033[0m\n", fail);
+    }
+    if (warns) {
+        printf("\033[0;33m%d warnings\033[0m\n", warns);
+    }
+    printf("Tests performed:\n");
+    for (int i = 0; rule_tests[i].func; ++i) {
+        if (!tests[i]) {
+            continue;
+        }
+        printf("  #%d %s\n", i+1, rule_tests[i].name);
     }
     return fail;
 }

--- a/tester/test_backspace.c
+++ b/tester/test_backspace.c
@@ -18,17 +18,12 @@ void sim_st_enhanced_backspace(const uint16_t *keycodes)
 //////////////////////////////////////////////////////////////////////
 void test_backspace(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[256];
-    res->message = message;
     // This expects input and output buffers to have been set by a previous test!
     // Make sure enhanced backspace handling leaves us with an empty
     // output buffer if we send one backspace for every key sent
     sim_st_enhanced_backspace(rule->seq_keycodes);
     const int out_size = sim_output_get_size();
-    res->pass = out_size == 0;
-    if (res->pass) {
-        snprintf(message, sizeof(message), "OK!");
-    } else {
-        snprintf(message, sizeof(message), "left %d keys in buffer!", out_size);
+    if (out_size != 0) {
+        RES_FAIL("left %d keys in buffer!", out_size);
     }
 }

--- a/tester/test_backspace.c
+++ b/tester/test_backspace.c
@@ -18,7 +18,7 @@ void sim_st_enhanced_backspace(const uint16_t *keycodes)
 //////////////////////////////////////////////////////////////////////
 void test_backspace(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    // This expects input and output buffers to have been set by a previous test!
+    sim_st_perform(rule->seq_keycodes);
     // Make sure enhanced backspace handling leaves us with an empty
     // output buffer if we send one backspace for every key sent
     sim_st_enhanced_backspace(rule->seq_keycodes);

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -13,30 +13,23 @@
 //////////////////////////////////////////////////////////////////////
 void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[512];
-    res->message = message;
     st_cursor_t *cursor = st_get_cursor();
     st_cursor_init(cursor, 0, false);
     for (int i = 0; i < 200; ++i) {
         st_cursor_next(cursor);
     }
-    res->pass = cursor->cursor_pos.index == cursor->buffer->context_len;
-    if (!res->pass) {
-        snprintf(message, sizeof(message), "input cursor didn't stop at end: cursor index %d; context_len: %d",
-                    cursor->cursor_pos.index,
-                    cursor->buffer->context_len);
+    if (cursor->cursor_pos.index != cursor->buffer->context_len) {
+        RES_FAIL("input cursor didn't stop at end: cursor index %d; context_len: %d",
+                 cursor->cursor_pos.index, cursor->buffer->context_len);
+        return;
     }
     if (st_cursor_init(cursor, 0, true)) {
         for (int i = 0; i < 200; ++i) {
             st_cursor_next(cursor);
         }
     }
-    res->pass = cursor->cursor_pos.index == cursor->buffer->context_len;
-    if (res->pass) {
-        snprintf(message, sizeof(message), "OK!");
-    } else {
-        snprintf(message, sizeof(message), "output cursor didn't stop at end: cursor index %d; context_len: %d",
-                    cursor->cursor_pos.index,
-                    cursor->buffer->context_len);
+    if (cursor->cursor_pos.index != cursor->buffer->context_len) {
+        RES_FAIL("output cursor didn't stop at end: cursor index %d; context_len: %d",
+                 cursor->cursor_pos.index, cursor->buffer->context_len);
     }
 }

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -13,6 +13,7 @@
 //////////////////////////////////////////////////////////////////////
 void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
 {
+    sim_st_perform(rule->seq_keycodes);
     st_cursor_t *cursor = st_get_cursor();
     st_cursor_init(cursor, 0, false);
     for (int i = 0; i < 200; ++i) {

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -12,12 +12,6 @@
 
 #define KEY_AT(i) st_key_buffer_get_keycode(buf, (i))
 
-// fixme: TEMP! will be in utils
-bool is_seq_token_keycode(uint16_t key)
-{
-    return (key >= SPECIAL_KEY_TRIECODE_0 &&
-            key < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT);
-}
 //////////////////////////////////////////////////////////////////
 // Converts keys from buffer to null terminated ascii string
 // KC_SPACE -> ' ' (instead of st_wordbreak_ascii)
@@ -35,7 +29,7 @@ bool buf_needs_expanding(st_key_buffer_t *buf)
 {
     for (int i = 1; i < buf->context_len; ++i) {
         const uint16_t key = KEY_AT(i);
-        if (is_seq_token_keycode(key)) {
+        if (st_is_seq_token_keycode(key)) {
             return true;
         }
     }
@@ -83,7 +77,7 @@ bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transf
         tap_code16(KC_BSPC);
         st_handle_backspace();
         key = KEY_AT(0);
-    } while (key && !is_seq_token_keycode(key));
+    } while (key && !st_is_seq_token_keycode(key));
     if (!key) {
         //printf("empty seq_prefix!\n");
         return false;

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -18,6 +18,18 @@ bool is_seq_token_keycode(uint16_t key)
     return (key >= SPECIAL_KEY_TRIECODE_0 &&
             key < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT);
 }
+//////////////////////////////////////////////////////////////////
+// Converts keys from buffer to null terminated ascii string
+// KC_SPACE -> ' ' (instead of st_wordbreak_ascii)
+void key_buffer_to_space_str(const st_key_buffer_t *buf, char *str)
+{
+    const int len = buf->context_len;
+    for (int i = 0; i < len; ++i) {
+        const uint16_t key = KEY_AT(len - i - 1);
+        *str++ = key == KC_SPACE ? ' ' : st_keycode_to_char(key);
+    }
+    *str = 0;
+}
 //////////////////////////////////////////////////////////////////////
 bool buf_needs_expanding(st_key_buffer_t *buf)
 {
@@ -30,68 +42,78 @@ bool buf_needs_expanding(st_key_buffer_t *buf)
     return false;
 }
 //////////////////////////////////////////////////////////////////////
-// (partial) simulation of process_sequence_transform logic
-// to test st_find_missed_rule
-// returns false if rule is untestable
-bool sim_st_find_missed_rule(const st_test_rule_t *rule, char *chained_transform)
+// Setup input buffer from rule transform so that
+// it's ready for the st_find_missed_rule call.
+// Fills chained_transform with an ascii string of the actual transform
+// that will be tested.
+// returns false if rule is untestable, true otherwise
+bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transform)
 {    
     st_key_buffer_t *buf = st_get_key_buffer();
     // send input rule seq so we can get output transform to test
     sim_st_perform(rule->seq_keycodes);
 
-    if (buf_needs_expanding(buf)) {
-        // find seq_prefix/trans_prefix by backspacing non seq tokens
-        uint16_t key = 0;
-        do {
-            tap_code16(KC_BSPC);
-            st_handle_backspace();
-            key = KEY_AT(0);
-        } while (key && !is_seq_token_keycode(key));
-        if (!key) {
-            //printf("empty seq_prefix!\n");
-            return false;
-        }
-        char *trans_prefix = sim_output_get(true);
-        int   out_len = strlen(trans_prefix);
-        int   rule_trans_len = strlen(rule->transform_str);
-        //printf("trans_prefix: %s\n", trans_prefix);
-        if (!strstr(rule->transform_str, trans_prefix)) {
-            // If trans_prefix is not in transform_str,
-            // this is an untestable rule. 
-            return false;
-        }
-        // output now contains trans_prefix (develop)
-        // input now contains seq_prefix (^d@)
-        // add removed chars (er) to new end of sequence in input buffer
-        for (int i = out_len; i < rule_trans_len; ++i) {
-            const char     c   = rule->transform_str[i];
-            const uint16_t key = ascii_to_keycode(c);
-            st_key_buffer_push(buf, key);
-        }
-        // input should now contain ^d@er
-        st_key_buffer_to_str(buf, chained_transform, buf->context_len);
-        //printf("chained_transform: %s\n", chained_transform);
-        if (!strcmp(chained_transform, rule->transform_str)) {
-            // transform already a chained expression,
-            // so nothing to test!
-            return false;
-        }
-    } else {
-        buf->context_len = 0;
+    // Check if sequence contains an unexpanded token
+    if (!buf_needs_expanding(buf)) {
+        // 'normal' rule, so we can use the transform as is
+        chained_transform[0] = 0;
+        strncat(chained_transform, rule->transform_str, 255);        
         // send the output into input buffer
         // to simulate user typing it directly
+        buf->context_len = 0;
         char *output = sim_output_get(false);
         for (char c = *output; c; c = *++output) {
             const uint16_t key = ascii_to_keycode(c);
             st_key_buffer_push(buf, key);
-        }
-        chained_transform[0] = 0;
-        strncat(chained_transform, rule->transform_str, 255);
+        }        
+        return true;
     }
-    // from this new input buffer, find missed rule
-    missed_rule_seq[0] = 0;
-    missed_rule_transform[0] = 0;
-    st_find_missed_rule();
+    // Rule contains a sequence token before the end so
+    // rule_search won't be able to find this rule
+    // if we use the expanded transform.
+    // We must instead convert it to a form that it could find.
+    // Example: ^d@r -> developer
+    // seq_prefix: ^d@
+    // trans_prefix: develop
+    // chained_transform: ^d@er
+
+    // find seq_prefix/trans_prefix by backspacing non seq tokens
+    uint16_t key = 0;
+    do {
+        tap_code16(KC_BSPC);
+        st_handle_backspace();
+        key = KEY_AT(0);
+    } while (key && !is_seq_token_keycode(key));
+    if (!key) {
+        //printf("empty seq_prefix!\n");
+        return false;
+    }
+    char *trans_prefix = sim_output_get(true);
+    int   out_len = strlen(trans_prefix);
+    int   rule_trans_len = strlen(rule->transform_str);
+    //printf("trans_prefix: %s\n", trans_prefix);
+    if (!strstr(rule->transform_str, trans_prefix)) {
+        // If trans_prefix is not in transform_str,
+        // this is an untestable rule. 
+        return false;
+    }
+    // output now contains trans_prefix (develop)
+    // input now contains seq_prefix (^d@)
+    // add removed chars (er) to new end of sequence in input buffer
+    for (int i = out_len; i < rule_trans_len; ++i) {
+        const char     c   = rule->transform_str[i];
+        const uint16_t key = ascii_to_keycode(c);
+        st_key_buffer_push(buf, key);
+    }
+    // input should now contain ^d@er and is ready for searching
+    key_buffer_to_space_str(buf, chained_transform);
+    //printf("chained_transform: %s\n", chained_transform);
+    if (!strcmp(ltrim_str(chained_transform), rule->transform_str)) {
+        // transform already a chained expression,
+        // so nothing to test!
+        //printf("transform already a chained expression!\n");
+        return false;
+    }
     return true;
 }
 //////////////////////////////////////////////////////////////////////
@@ -108,11 +130,20 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
         RES_WARN("untestable rule (space in transform)!");
         return;
     }
-    // Run the test
-    if (!sim_st_find_missed_rule(rule, chained_transform)) {
+    // setup input buffer from rule transform so that
+    // it's ready for the st_find_missed_rule call
+    if (!setup_input_from_transform(rule, chained_transform)) {
         RES_WARN("untestable rule!");
         return;
-    }    
+    }
+    // currently the rule transform string doesn't have leading spaces
+    // so we must remove them from our computed chained_transform
+    // before comparisons.
+    char *transform = ltrim_str(chained_transform);
+    // from this new input buffer, find missed rule
+    missed_rule_seq[0] = 0;
+    missed_rule_transform[0] = 0;
+    st_find_missed_rule();    
     // Check if found rule matches ours
     keycodes_to_ascii_str(rule->seq_keycodes, seq_ascii);
     const int missed_rule_seq_len = strlen(missed_rule_seq);
@@ -122,7 +153,7 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
         return;
     }
     const int seq_dif = strcmp(missed_rule_seq, seq_ascii);
-    const int trans_dif = strcmp(missed_rule_transform, chained_transform);
+    const int trans_dif = strcmp(missed_rule_transform, transform);
     if (!trans_dif && missed_rule_seq_len < seq_ascii_len) {
         RES_WARN("found shorter sequence rule: %s ⇒ %s",
                  missed_rule_seq, missed_rule_transform);
@@ -134,7 +165,7 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
         return;
     }
     if (seq_dif || trans_dif) {
-        //printf("(%s -> %s)\n", seq_ascii, chained_transform);
+        //printf("(%s -> %s)\n", seq_ascii, transform);
         RES_FAIL("found: %s ⇒ %s",
                  missed_rule_seq, missed_rule_transform);
         return;

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -2,6 +2,7 @@
 #include "keybuffer.h"
 #include "key_stack.h"
 #include "trie.h"
+#include "utils.h"
 #include "sequence_transform.h"
 #include "sequence_transform_data.h"
 #include "sequence_transform_test.h"
@@ -9,45 +10,131 @@
 #include "tester_utils.h"
 #include "tester.h"
 
+#define KEY_AT(i) st_key_buffer_get_keycode(buf, (i))
+
+// fixme: TEMP! will be in utils
+bool st_is_seq_token_keycode(uint16_t key)
+{
+    return (key >= SPECIAL_KEY_TRIECODE_0 &&
+            key < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT);
+}
+//////////////////////////////////////////////////////////////////////
+bool buf_needs_expanding(st_key_buffer_t *buf)
+{
+    for (int i = 1; i < buf->context_len; ++i) {
+        const uint16_t key = KEY_AT(i);
+        if (st_is_seq_token_keycode(key)) {
+            return true;
+        }
+    }
+    return false;
+}
 //////////////////////////////////////////////////////////////////////
 // (partial) simulation of process_sequence_transform logic
 // to test st_find_missed_rule
-void sim_st_find_missed_rule(const uint16_t *keycodes)
-{
-    missed_rule_seq[0] = 0;
-    missed_rule_transform[0] = 0;
+// returns false if rule is untestable
+bool sim_st_find_missed_rule(const st_test_rule_t *rule, char *chained_transform)
+{    
     st_key_buffer_t *buf = st_get_key_buffer();
-    // reset search_len_from_space by first sending a single space
-    st_key_buffer_push(buf, KC_SPACE);
-    st_find_missed_rule();
     // send input rule seq so we can get output transform to test
-    sim_st_perform(keycodes);
-    buf->context_len = 0;
-    // send the output into input buffer
-    // to simulate user typing it directly
-    char *output = sim_output_get(false);
-    for (char c = *output; c; c = *++output) {
-        const uint16_t key = ascii_to_keycode(c);
-        st_key_buffer_push(buf, key);
+    sim_st_perform(rule->seq_keycodes);
+
+    if (buf_needs_expanding(buf)) {
+        // find seq_prefix/trans_prefix by backspacing non seq tokens
+        uint16_t key = 0;
+        do {
+            tap_code16(KC_BSPC);
+            st_handle_backspace();
+            key = KEY_AT(0);
+        } while (key && !st_is_seq_token_keycode(key));
+        if (!key) {
+            //printf("empty seq_prefix!\n");
+            return false;
+        }
+        char *trans_prefix = sim_output_get(true);
+        int   out_len = strlen(trans_prefix);
+        int   rule_trans_len = strlen(rule->transform_str);
+        //printf("trans_prefix: %s\n", trans_prefix);
+        if (!strstr(rule->transform_str, trans_prefix)) {
+            // If trans_prefix is not in transform_str,
+            // this is an untestable rule. 
+            return false;
+        }
+        // output now contains trans_prefix (develop)
+        // input now contains seq_prefix (^d@)
+        // add removed chars (er) to new end of sequence in input buffer
+        for (int i = out_len; i < rule_trans_len; ++i) {
+            const char     c   = rule->transform_str[i];
+            const uint16_t key = ascii_to_keycode(c);
+            st_key_buffer_push(buf, key);
+        }
+        // input should now contain ^d@er
+        st_key_buffer_to_str(buf, chained_transform, buf->context_len);
+        //printf("chained_transform: %s\n", chained_transform);
+        if (!strcmp(chained_transform, rule->transform_str)) {
+            // transform already a chained expression,
+            // so nothing to test!
+            return false;
+        }
+    } else {
+        buf->context_len = 0;
+        // send the output into input buffer
+        // to simulate user typing it directly
+        char *output = sim_output_get(false);
+        for (char c = *output; c; c = *++output) {
+            const uint16_t key = ascii_to_keycode(c);
+            st_key_buffer_push(buf, key);
+        }
+        chained_transform[0] = 0;
+        strncat(chained_transform, rule->transform_str, 255);
     }
     // from this new input buffer, find missed rule
+    missed_rule_seq[0] = 0;
+    missed_rule_transform[0] = 0;
     st_find_missed_rule();
+    return true;
 }
 //////////////////////////////////////////////////////////////////////
 void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[256];
-    res->message = message;
-    sim_st_find_missed_rule(rule->seq_keycodes);
-    res->pass = !strcmp(missed_rule_transform, rule->transform_str);
-    if (res->pass) {
-        snprintf(message, sizeof(message), "OK!");
-    } else {
-        if (strlen(missed_rule_seq)) {
-            snprintf(message, sizeof(message), "found: %s ⇒ %s",
-                missed_rule_seq, missed_rule_transform);
-        } else {
-            snprintf(message, sizeof(message), "found nothing!");
-        }
+    char seq_ascii[256] = {0};
+    char chained_transform[256] = {0};
+    // rule search starts looking from the last space in the buffer
+    // so if there is a space in the rule transform,
+    // this rule is untestable (except if space is at the end)
+    char *space = strchr(rule->transform_str, ' ');
+    int transform_len = strlen(rule->transform_str);
+    if (space && space - rule->transform_str < transform_len - 1) {
+        RES_WARN("untestable rule (space in transform)!");
+        return;
+    }
+    // Run the test
+    if (!sim_st_find_missed_rule(rule, chained_transform)) {
+        RES_WARN("untestable rule!");
+        return;
+    }    
+    // Check if found rule matches ours
+    keycodes_to_ascii_str(rule->seq_keycodes, seq_ascii);
+    const int missed_rule_seq_len = strlen(missed_rule_seq);
+    const int seq_ascii_len = strlen(seq_ascii);
+    if (!missed_rule_seq_len) {
+        RES_FAIL("found nothing!");
+        return;
+    }
+    const int seq_dif = strcmp(missed_rule_seq, seq_ascii);
+    const int trans_dif = strcmp(missed_rule_transform, chained_transform);
+    if (!trans_dif && missed_rule_seq_len < seq_ascii_len) {
+        RES_WARN("found shorter sequence rule: %s ⇒ %s",
+                 missed_rule_seq, missed_rule_transform);
+        return;
+    }
+    if (!trans_dif && seq_dif) {
+        RES_WARN("found diff sequence for same transform: %s ⇒ %s",
+                 missed_rule_seq, missed_rule_transform);
+        return;
+    }
+    if (seq_dif || trans_dif) {
+        RES_FAIL("found: %s ⇒ %s", missed_rule_seq, missed_rule_transform);
+        return;
     }
 }

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -13,7 +13,7 @@
 #define KEY_AT(i) st_key_buffer_get_keycode(buf, (i))
 
 // fixme: TEMP! will be in utils
-bool st_is_seq_token_keycode(uint16_t key)
+bool is_seq_token_keycode(uint16_t key)
 {
     return (key >= SPECIAL_KEY_TRIECODE_0 &&
             key < SPECIAL_KEY_TRIECODE_0 + SEQUENCE_TRANSFORM_COUNT);
@@ -23,7 +23,7 @@ bool buf_needs_expanding(st_key_buffer_t *buf)
 {
     for (int i = 1; i < buf->context_len; ++i) {
         const uint16_t key = KEY_AT(i);
-        if (st_is_seq_token_keycode(key)) {
+        if (is_seq_token_keycode(key)) {
             return true;
         }
     }
@@ -46,7 +46,7 @@ bool sim_st_find_missed_rule(const st_test_rule_t *rule, char *chained_transform
             tap_code16(KC_BSPC);
             st_handle_backspace();
             key = KEY_AT(0);
-        } while (key && !st_is_seq_token_keycode(key));
+        } while (key && !is_seq_token_keycode(key));
         if (!key) {
             //printf("empty seq_prefix!\n");
             return false;
@@ -134,7 +134,9 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
         return;
     }
     if (seq_dif || trans_dif) {
-        RES_FAIL("found: %s ⇒ %s", missed_rule_seq, missed_rule_transform);
+        //printf("(%s -> %s)\n", seq_ascii, chained_transform);
+        RES_FAIL("found: %s ⇒ %s",
+                 missed_rule_seq, missed_rule_transform);
         return;
     }
 }

--- a/tester/test_perform.c
+++ b/tester/test_perform.c
@@ -28,16 +28,11 @@ void sim_st_perform(const uint16_t *keycodes)
 //////////////////////////////////////////////////////////////////////
 void test_perform(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[256];
-    res->message = message;
     sim_st_perform(rule->seq_keycodes);
     // Ignore spaces at the start of output
     char *output = sim_output_get(true);
     // Check if our output buffer matches the expected transform string
-    res->pass = !strcmp(output, rule->transform_str);
-    if (res->pass) {
-        snprintf(message, sizeof(message), "OK!");
-    } else {
-        snprintf(message, sizeof(message), "output: %s", output);
+    if (strcmp(output, rule->transform_str)) {
+        RES_FAIL("output: %s", output);
     }
 }

--- a/tester/test_virtual_output.c
+++ b/tester/test_virtual_output.c
@@ -22,7 +22,7 @@ bool compare_output(char *virtual_output, char *sim_output, int count)
 //////////////////////////////////////////////////////////////////////
 void test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    // sim_st_perform was run in a previous test
+    sim_st_perform(rule->seq_keycodes);
     char *sim_output = sim_output_get(false);
     const int sim_len = sim_output_get_size();
     char virtual_output[256] = {0};

--- a/tester/test_virtual_output.c
+++ b/tester/test_virtual_output.c
@@ -22,21 +22,16 @@ bool compare_output(char *virtual_output, char *sim_output, int count)
 //////////////////////////////////////////////////////////////////////
 void test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res)
 {
-    static char message[512];
-    res->message = message;
     // sim_st_perform was run in a previous test
     char *sim_output = sim_output_get(false);
     const int sim_len = sim_output_get_size();
-    char virtual_output[256];
+    char virtual_output[256] = {0};
     const int virt_len = st_get_virtual_output(virtual_output, 255);
     if (virt_len != sim_len) {
-        res->pass = false;
-        snprintf(message, sizeof(message), "virt len (%d) != sim len (%d)", virt_len, sim_len);
+        RES_FAIL("virt len (%d) != sim len (%d)", virt_len, sim_len);
+        return;
     }
-    res->pass = compare_output(virtual_output, sim_output, virt_len);
-    if (res->pass) {
-        snprintf(message, sizeof(message), "OK!");
-    } else {
-        snprintf(message, sizeof(message), "mismatch! virt: |%s| sim: |%s|", virtual_output, sim_output);
+    if (!compare_output(virtual_output, sim_output, virt_len)) {
+        RES_FAIL("mismatch! virt: |%s| sim: |%s|", virtual_output, sim_output);
     }
 }

--- a/tester/tester.c
+++ b/tester/tester.c
@@ -3,6 +3,7 @@
 // Copyright 2024 QKekos <q.kekos.q@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdlib.h>
 #include "qmk_wrapper.h"
 #include "utils.h"
 #include "keybuffer.h"
@@ -62,17 +63,47 @@ void tap_code16(uint16_t keycode)
     }
 }
 //////////////////////////////////////////////////////////////////////
+void print_help(void)
+{
+    printf("Sequence Transform Tester usage:\n");
+    printf("tester [-p] [-t <tests>] [-s <test_bit_string>]\n");
+    puts("");
+    printf("By default, all tests will be performed on all compiled rules.\n");
+    printf("Only test failures and warnings will be shown.\n");
+    puts("");
+    printf("  -p print all tested rules\n");
+    puts("");
+    printf("  -s run simulation of sequence transform of passed <test_string>,\n");
+    printf("     one char at a time. Ascii sequence tokens and wordbreak symbol\n");
+    printf("     can be used, as defined in your sequence_transform_config.json file.\n");
+    puts("");
+    printf("  -t each bit in <test_bit_string> turns a test on or off.\n");
+    printf("     ex: -t \"101\" would only run tests #1 and #3.\n");
+    puts("");
+    printf("Available tests:\n");
+    print_available_tests();
+}
+//////////////////////////////////////////////////////////////////////
 void init_options(int argc, char **argv, st_test_options_t *options)
 {
+    // default action is to test all rules
     options->action = ACTION_TEST_ALL_RULES;
+    options->tests = 0;
     options->user_str = 0;
+    // default is to only print errors/warnings
     options->print_all = false;
+    // get options from command line args
     for (int i = 1; i < argc; ++i) {
         if (!strcmp(argv[i], "-p")) {
             options->print_all = true;
         } else if (!strcmp(argv[i], "-s") && i+1 < argc) {
             options->user_str = argv[i+1];
             options->action = ACTION_TEST_ASCII_STRING;
+        } else if (!strcmp(argv[i], "-t") && i+1 < argc) {
+            options->tests = argv[i+1];
+        } else if (!strcmp(argv[i], "-h")) {
+            print_help();
+            exit(0);
         }
     }
 }

--- a/tester/tester.h
+++ b/tester/tester.h
@@ -3,9 +3,11 @@
 extern char missed_rule_seq[SEQUENCE_MAX_LENGTH + 1];
 extern char missed_rule_transform[TRANSFORM_MAX_LEN + 1];
 
-#define TEST_FAIL   0
-#define TEST_WARN   1
-#define TEST_OK     2
+typedef enum {
+    TEST_FAIL,
+    TEST_WARN,
+    TEST_OK,
+} st_result_code_t;
 
 // Utility macros to set result code/message
 #define RES_WARN(...) { res->code = TEST_WARN; \
@@ -15,8 +17,8 @@ extern char missed_rule_transform[TRANSFORM_MAX_LEN + 1];
     snprintf(res->message, sizeof(res->message), __VA_ARGS__); }
 
 typedef struct {
-    int     code;
-    char    message[512];
+    st_result_code_t    code;
+    char                message[512];
 } st_test_result_t;
 
 typedef void (*st_test_func_t)(const st_test_rule_t *, st_test_result_t *);

--- a/tester/tester.h
+++ b/tester/tester.h
@@ -3,15 +3,26 @@
 extern char missed_rule_seq[SEQUENCE_MAX_LENGTH + 1];
 extern char missed_rule_transform[TRANSFORM_MAX_LEN + 1];
 
+#define TEST_FAIL   0
+#define TEST_WARN   1
+#define TEST_OK     2
+
+// Utility macros to set result code/message
+#define RES_WARN(...) { res->code = TEST_WARN; \
+    snprintf(res->message, sizeof(res->message), __VA_ARGS__); }
+
+#define RES_FAIL(...) { res->code = TEST_FAIL; \
+    snprintf(res->message, sizeof(res->message), __VA_ARGS__); }
+
 typedef struct {
-    bool    pass;
-    char    *message;
+    int     code;
+    char    message[512];
 } st_test_result_t;
 
 typedef void (*st_test_func_t)(const st_test_rule_t *, st_test_result_t *);
 
 typedef struct {
-    st_test_func_t         func;
+    st_test_func_t      func;
     const char          *name;
     st_test_result_t    res;
 } st_test_info_t;
@@ -26,8 +37,6 @@ typedef int (*st_test_action_t)(const st_test_options_t *);
 
 //      Internal
 void    sim_st_perform(const uint16_t *keycodes);
-void    sim_st_enhanced_backspace(const uint16_t *keycodes);
-void    sim_st_find_missed_rule(const uint16_t *keycodes);
 
 //      Rule tests
 void    test_perform(const st_test_rule_t *rule, st_test_result_t *res);

--- a/tester/tester.h
+++ b/tester/tester.h
@@ -30,10 +30,13 @@ typedef struct {
 typedef struct {
     int     action;
     char    *user_str;
+    char    *tests;
     bool    print_all;
 } st_test_options_t;
 
 typedef int (*st_test_action_t)(const st_test_options_t *);
+
+void    print_available_tests(void);
 
 //      Internal
 void    sim_st_perform(const uint16_t *keycodes);
@@ -44,7 +47,7 @@ void    test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_cursor(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_backspace(const st_test_rule_t *rule, st_test_result_t *res);
 void    test_find_rule(const st_test_rule_t *rule, st_test_result_t *res);
-int     test_rule(const st_test_rule_t *rule, bool print_all);
+int     test_rule(const st_test_rule_t *rule, bool *tests, bool print_all, int *warns);
 
 //      Test Actions
 int     test_all_rules(const st_test_options_t *options);

--- a/tester/tester.vcxproj
+++ b/tester/tester.vcxproj
@@ -90,7 +90,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER;SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(QMKPATH)\platforms;$(QMKPATH)\quantum;$(QMKPATH)\quantum\sequencer;$(QMKPATH)\quantum\logging;$(QMKPATH)\quantum\keymap_extras;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -107,7 +107,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER;SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(QMKPATH)\platforms;$(QMKPATH)\quantum;$(QMKPATH)\quantum\sequencer;$(QMKPATH)\quantum\logging;$(QMKPATH)\quantum\keymap_extras;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -124,7 +124,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER;SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(QMKPATH)\platforms;$(QMKPATH)\quantum;$(QMKPATH)\quantum\sequencer;$(QMKPATH)\quantum\logging;$(QMKPATH)\quantum\keymap_extras;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -141,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER;SEQUENCE_TRANSFORM_TRIE_SANITY_CHECKS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);NO_PRINT;ST_TESTER;WIN32;SEQUENCE_TRANSFORM_MISSED_RULES;_CRT_SECURE_NO_WARNINGS;SEQUENCE_TRANSFORM_ENABLE_FALLBACK_BUFFER</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(QMKPATH)\platforms;$(QMKPATH)\quantum;$(QMKPATH)\quantum\sequencer;$(QMKPATH)\quantum\logging;$(QMKPATH)\quantum\keymap_extras;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/tester/tester_utils.c
+++ b/tester/tester_utils.c
@@ -51,3 +51,10 @@ uint16_t ascii_to_keycode(char c)
     }
     return st_char_to_keycode(c);
 }
+//////////////////////////////////////////////////////////////////
+// returns a pointer to the first non-space char in string
+char *ltrim_str(char *str)
+{
+    while (*str++ == ' ');
+    return --str;
+}

--- a/tester/tester_utils.h
+++ b/tester/tester_utils.h
@@ -4,3 +4,4 @@ const char  *st_get_seq_token_symbol(uint16_t keycode);
 void        keycodes_to_utf8_str(const uint16_t *keycodes, char *str);
 void        keycodes_to_ascii_str(const uint16_t *keycodes, char *str);
 uint16_t    ascii_to_keycode(char c);
+char        *ltrim_str(char *str);


### PR DESCRIPTION
- Changes were made to the tester's rule_search tests to support the new algo fixes, including reporting `WARN` for untestable rules. `WARN` is also reported if rule search finds a rule with a shorter or different sequence string that matches the transform string.

- Tests can use helper macros `RES_FAIL` and `RES_WARN` to make things easier to read.

- Tester Makefile was updated to automatically compile all src files in tester and lib folder. It now has default values for env vars used, which can be changed via the cli when calling make. It now calls the generator if the dict/config have changed.

- A new -h command line option was added that shows info about the available parameters.

- A new -t command line option was added that allows us to select which tests to run. `./tester -t "101"` would only run tests 1 and 3. All tests are now independent, and don't rely on a previous test to setup the input buffer.

- Test summary has been changed slightly for easier reading. Now shows number of rules tested, all pass or number fails, and number of warnings, and which tests were run.