### PR TITLE
Const cleanup

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -17,7 +17,7 @@
 //////////////////////////////////////////////////////////////////
 bool cursor_advance_to_valid_output(st_cursor_t *cursor)
 {
-    st_trie_payload_t *action = st_cursor_get_action(cursor);
+    const st_trie_payload_t *action = st_cursor_get_action(cursor);
     if (cursor->cursor_pos.sub_index < action->completion_len) {
         // current sub-index is valid; no need to advance
         return true;
@@ -32,7 +32,7 @@ bool cursor_advance_to_valid_output(st_cursor_t *cursor)
             return false;
         }
         cursor->cache_valid = false;
-        st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
+        const st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->pos.index);
         // Below is an assert that should be made
         // if (!keyaction) {
         //     // We reached the end without finding the next output key
@@ -102,13 +102,13 @@ uint16_t st_cursor_get_keycode(st_cursor_t *cursor)
 // DO NOT USE externally when cursor is initialized to act
 // as a virtual output. Behavior is not stable in the presence
 // of `st_cursor_get_keycode` in virtual output mode
-st_trie_payload_t *st_cursor_get_action(st_cursor_t *cursor)
+const st_trie_payload_t *st_cursor_get_action(st_cursor_t *cursor)
 {
     st_trie_payload_t *action = &cursor->cached_action;
     if (cursor->cache_valid) {
         return action;
     }
-    const st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
+    const st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->pos.index);
     if (!keyaction) {
         return NULL;
     }
@@ -143,7 +143,7 @@ bool st_cursor_next(st_cursor_t *cursor)
         return true;
     }
     // Continue processing if simulating output buffer
-    st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->cursor_pos.index);
+    const st_key_action_t *keyaction = st_key_buffer_get(cursor->buffer, cursor->pos.index);
     if (!keyaction) {
         return false;
     }
@@ -200,15 +200,17 @@ void st_cursor_print(st_cursor_t *cursor)
     st_cursor_restore(cursor, &cursor_pos);
 }
 //////////////////////////////////////////////////////////////////
-bool st_cursor_push_to_stack(st_cursor_t *cursor, int count)
+bool st_cursor_push_to_stack(st_cursor_t *cursor,
+                             st_key_stack_t *key_stack,
+                             int count)
 {
-    cursor->trie->key_stack->size = 0;
+    key_stack->size = 0;
     for (; count > 0; --count, st_cursor_next(cursor)) {
         const uint16_t keycode = st_cursor_get_keycode(cursor);
         if (!keycode) {
             return false;
         }
-        st_key_stack_push(cursor->trie->key_stack, keycode);
+        st_key_stack_push(key_stack, keycode);
     }
     return true;
 }

--- a/cursor.h
+++ b/cursor.h
@@ -13,11 +13,11 @@
 
 bool                    st_cursor_init(st_cursor_t *cursor, int history, uint8_t as_output);
 uint16_t                st_cursor_get_keycode(st_cursor_t *cursor);
-st_trie_payload_t       *st_cursor_get_action(st_cursor_t *cursor);
+const st_trie_payload_t *st_cursor_get_action(st_cursor_t *cursor);
 bool                    st_cursor_at_end(const st_cursor_t *cursor);
 bool                    st_cursor_next(st_cursor_t *cursor);
 st_cursor_pos_t         st_cursor_save(const st_cursor_t *cursor);
 void                    st_cursor_restore(st_cursor_t *cursor, st_cursor_pos_t *cursor_pos);
 bool                    st_cursor_longer_than(const st_cursor_t *cursor, const st_cursor_pos_t *past_pos);
-bool                    st_cursor_push_to_stack(st_cursor_t *cursor, int count);
+bool                    st_cursor_push_to_stack(st_cursor_t *cursor, st_key_stack_t *key_stack, int count);
 void                    st_cursor_print(st_cursor_t *cursor);

--- a/keybuffer.h
+++ b/keybuffer.h
@@ -22,7 +22,7 @@ typedef struct
 typedef struct
 {
     st_key_action_t * const data;       // array of keycodes
-    const int               capacity;   // buffer size
+    const int               capacity;   // max buffer size
     int                     size;       // number of current keys in buffer
     int                     head;       // current head for circular access
 } st_key_buffer_t;

--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -33,16 +33,16 @@ static inline void sequence_transform_task(void) {}
 //////////////////////////////////////////////////////////////////
 // Internal
 
-bool st_process_check(uint16_t *keycode, keyrecord_t *record, uint8_t *mods);
+bool st_process_check(uint16_t *keycode, const keyrecord_t *record, uint8_t *mods);
 void st_handle_repeat_key(void);
-void st_handle_result(st_trie_t *trie, st_trie_search_result_t *res);
+void st_handle_result(const st_trie_t *trie, const st_trie_search_result_t *res);
 bool st_perform(void);
 void st_find_missed_rule(void);
 void st_handle_backspace(void);
-uint8_t st_get_virtual_output(char *buf, uint8_t count);
+uint8_t st_get_virtual_output(char *str, uint8_t count);
 
 #ifdef ST_TESTER
-st_trie_t       *st_get_trie(void);
+const st_trie_t *st_get_trie(void);
 st_key_buffer_t *st_get_key_buffer(void);
-st_cursor_t *st_get_cursor(void);
+st_cursor_t     *st_get_cursor(void);
 #endif

--- a/tester/sim_output_buffer.c
+++ b/tester/sim_output_buffer.c
@@ -31,7 +31,7 @@ void sim_output_pop(int n)
     sim_output_buffer[sim_output_buffer_size] = 0;
 }
 //////////////////////////////////////////////////////////////////
-char *sim_output_get(bool trim_spaces)
+const char *sim_output_get(bool trim_spaces)
 {
     if (!trim_spaces) {
         return sim_output_buffer;

--- a/tester/sim_output_buffer.h
+++ b/tester/sim_output_buffer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void    sim_output_reset(void);
-void    sim_output_push(char c);
-void    sim_output_pop(int n);
-char    *sim_output_get(bool trim_spaces);
-int     sim_output_get_size();
-void    sim_output_print();
+void        sim_output_reset(void);
+void        sim_output_push(char c);
+void        sim_output_pop(int n);
+const char  *sim_output_get(bool trim_spaces);
+int         sim_output_get_size();
+void        sim_output_print();

--- a/tester/test_cursor.c
+++ b/tester/test_cursor.c
@@ -12,9 +12,9 @@ void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
     for (int i = 0; i < 200; ++i) {
         st_cursor_next(cursor);
     }
-    if (cursor->cursor_pos.index != cursor->buffer->size) {
+    if (cursor->pos.index != cursor->buffer->size) {
         RES_FAIL("input cursor didn't stop at end: cursor index %d; buffer size: %d",
-                 cursor->cursor_pos.index, cursor->buffer->size);
+                 cursor->pos.index, cursor->buffer->size);
         return;
     }
     if (st_cursor_init(cursor, 0, true)) {
@@ -22,8 +22,8 @@ void test_cursor(const st_test_rule_t *rule, st_test_result_t *res)
             st_cursor_next(cursor);
         }
     }
-    if (cursor->cursor_pos.index != cursor->buffer->size) {
+    if (cursor->pos.index != cursor->buffer->size) {
         RES_FAIL("output cursor didn't stop at end: cursor index %d; buffer size: %d",
-                 cursor->cursor_pos.index, cursor->buffer->size);
+                 cursor->pos.index, cursor->buffer->size);
     }
 }

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -51,7 +51,7 @@ bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transf
         // send the output into input buffer
         // to simulate user typing it directly
         buf->size = 0;
-        char *output = sim_output_get(false);
+        const char *output = sim_output_get(false);
         for (char c = *output; c; c = *++output) {
             const uint16_t key = ascii_to_keycode(c);
             st_key_buffer_push(buf, key);
@@ -78,7 +78,7 @@ bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transf
         //printf("empty seq_prefix!\n");
         return false;
     }
-    char *trans_prefix = sim_output_get(true);
+    const char *trans_prefix = sim_output_get(true);
     int   out_len = strlen(trans_prefix);
     int   rule_trans_len = strlen(rule->transform_str);
     //printf("trans_prefix: %s\n", trans_prefix);

--- a/tester/test_perform.c
+++ b/tester/test_perform.c
@@ -28,7 +28,7 @@ void test_perform(const st_test_rule_t *rule, st_test_result_t *res)
 {
     sim_st_perform(rule->seq_keycodes);
     // Ignore spaces at the start of output
-    char *output = sim_output_get(true);
+    const char *output = sim_output_get(true);
     // Check if our output buffer matches the expected transform string
     if (strcmp(output, rule->transform_str)) {
         RES_FAIL("output: %s", output);

--- a/tester/test_virtual_output.c
+++ b/tester/test_virtual_output.c
@@ -7,7 +7,7 @@
 //////////////////////////////////////////////////////////////////
 // compare the virtual output buffer state to the sim output buffer
 // FIXME: we should really be comparing keycodes instead of chars!
-bool compare_output(char *virtual_output, char *sim_output, int count)
+bool compare_output(char *virtual_output, const char *sim_output, int count)
 {
     for (int i = 0; i < count; i++) {
         const char simc = sim_output[i];
@@ -22,7 +22,7 @@ bool compare_output(char *virtual_output, char *sim_output, int count)
 void test_virtual_output(const st_test_rule_t *rule, st_test_result_t *res)
 {
     sim_st_perform(rule->seq_keycodes);
-    char *sim_output = sim_output_get(false);
+    const char *sim_output = sim_output_get(false);
     const int sim_len = sim_output_get_size();
     char virtual_output[256] = {0};
     const int virt_len = st_get_virtual_output(virtual_output, 255);

--- a/trie.c
+++ b/trie.c
@@ -160,22 +160,21 @@ bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, 
  *
  * @param trie              trie_t struct containing trie data/size
  * @param key_buffer        current user input key buffer
+ * @param key_stack         stack used to record visited sequences
  * @param word_start_idx    index to space before last word in buffer
  * @param rule              pointer to rule result to fill if match found
  * @return                  true if match found that reaches end of key_buffer
  */
-bool st_trie_do_rule_searches(st_trie_t              *trie,
-                              const st_key_buffer_t  *key_buffer,
-                              int                    word_start_idx,
-                              st_trie_rule_t         *rule)
+bool st_trie_do_rule_searches(const st_trie_t       *trie,
+                              const st_key_buffer_t *key_buffer,
+                              st_key_stack_t        *key_stack,
+                              int                   word_start_idx,
+                              st_trie_rule_t        *rule)
 {
     // Convert word_start_index to reverse index
     const int search_base_ridx = st_clamp(key_buffer->size - word_start_idx,
                                           1, key_buffer->size - 1);
-    st_trie_search_t search;
-    search.trie = trie;
-    search.key_buffer = key_buffer;
-    search.result = rule;
+    st_trie_search_t search = {trie, key_buffer, key_stack, 0, 0, rule};
     const int max_skip_levels = st_min(1 + trie->max_backspaces,
                                        SEQUENCE_TRANSFORM_RULE_SEARCH_MAX_SKIP);
     for (int i = search_base_ridx; i < key_buffer->size; ++i) {
@@ -184,7 +183,7 @@ bool st_trie_do_rule_searches(st_trie_t              *trie,
         for (search.skip_levels = 1; search.skip_levels <= max_skip_levels; ++search.skip_levels) {
             search.search_end_ridx = i + search.skip_levels;
             st_debug(ST_DBG_RULE_SEARCH, "searching from ridx %d, skips: %d\n", i, search.skip_levels);
-            trie->key_stack->size = 0;
+            key_stack->size = 0;
             if (st_trie_rule_search(&search, 0)) {
                 return true;
             }
@@ -201,8 +200,8 @@ void debug_rule_match(const st_trie_payload_t *payload,
                       uint16_t offset)
 {
 #if SEQUENCE_TRANSFORM_DEBUG
-    st_trie_t *trie = search->trie;
-    const st_key_stack_t *key_stack = trie->key_stack;
+    const st_trie_t *trie = search->trie;
+    const st_key_stack_t *key_stack = search->key_stack;
     char stackstr[key_stack->size + 1];
     char compstr[payload->completion_len + 1];
     st_completion_to_str(trie, payload, compstr);
@@ -221,9 +220,9 @@ bool st_trie_rule_search(st_trie_search_t *search, uint16_t offset)
 {
 // Simulate future buffer keys by offsetting buffer access
 #define OFFSET_BUFFER_VAL st_key_buffer_get_keycode(key_buffer, key_stack->size - search->search_end_ridx)
-    st_trie_t *trie = search->trie;
+    const st_trie_t *trie = search->trie;
     const st_key_buffer_t *key_buffer = search->key_buffer;
-    st_key_stack_t *key_stack = trie->key_stack;
+    st_key_stack_t *key_stack = search->key_stack;
     uint16_t code = TDATA(trie, offset);
     // Match Node if bit 15 is set
     if (code & TRIE_MATCH_BIT) {
@@ -306,8 +305,8 @@ bool stack_contains_unexpanded_seq(const st_key_stack_t *s)
 //////////////////////////////////////////////////////////////////////
 bool st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *search)
 {
-    st_trie_t *trie = search->trie;
-    const st_key_stack_t *key_stack = trie->key_stack;
+    const st_trie_t *trie = search->trie;
+    const st_key_stack_t *key_stack = search->key_stack;
     const st_key_buffer_t *key_buffer = search->key_buffer;
     st_trie_rule_t *res = search->result;
     // Early return if potential transform doesn't reach end of search buffer

--- a/trie.c
+++ b/trie.c
@@ -131,7 +131,7 @@ bool st_find_longest_chain(st_cursor_t *cursor, st_trie_match_t *longest_match, 
         // Match Node if bit 15 is set
         if (code & TRIE_MATCH_BIT) {
             st_debug(ST_DBG_SEQ_MATCH, "New Match found: (%d, %d) %d\n",
-                cursor->cursor_pos.index, cursor->cursor_pos.sub_index, cursor->cursor_pos.segment_len);
+                cursor->pos.index, cursor->pos.sub_index, cursor->pos.segment_len);
             st_debug(ST_DBG_SEQ_MATCH, "Previous Match: (%d, %d) %d\n",
                 longest_match->seq_match_pos.index, longest_match->seq_match_pos.sub_index, longest_match->seq_match_pos.segment_len);
             // record this if it is the longest match

--- a/trie.h
+++ b/trie.h
@@ -53,7 +53,7 @@ typedef struct
 {
     const st_key_buffer_t * const buffer;           // input buffer this cursor traverses
     const st_trie_t * const       trie;             // trie used for traversing virtual output buffer
-    st_cursor_pos_t               cursor_pos;       // Contains all position info for the cursor
+    st_cursor_pos_t               pos;              // Contains all position info for the cursor
     st_trie_payload_t             cached_action;
     uint8_t                       cache_valid;
 } st_cursor_t;

--- a/trie.h
+++ b/trie.h
@@ -25,10 +25,10 @@
 
 typedef struct
 {
-    int     completion_index;   // index to start of completion string in trie_t.completions
-    int     completion_len;     // length of completion string
-    int     num_backspaces;     // number of backspaces to send before the completion string
-    int     func_code;          // special function code
+    int completion_index;   // index to start of completion string in trie_t.completions
+    int completion_len;     // length of completion string
+    int num_backspaces;     // number of backspaces to send before the completion string
+    int func_code;          // special function code
 } st_trie_payload_t;
 
 typedef struct
@@ -41,19 +41,18 @@ typedef struct
 
 typedef struct
 {
-    int             data_size;          // size in words of data buffer
-    const uint16_t  *data;              // serialized trie node data
-    int             completions_size;   // size in bytes of completions data buffer
-    const uint8_t   *completions;       // packed completions strings buffer
-    int             completion_max_len; // max len of all completion strings
-    int             max_backspaces;     // max backspaces for all completions
-    st_key_stack_t * const  key_stack;  // key stack used for searches
+    int            data_size;          // size in words of data buffer
+    const uint16_t *data;              // serialized trie node data
+    int            completions_size;   // size in bytes of completions data buffer
+    const uint8_t  *completions;       // packed completions strings buffer
+    int            completion_max_len; // max len of all completion strings
+    int            max_backspaces;     // max backspaces for all completions
 } st_trie_t;
 
 typedef struct
 {
-    st_key_buffer_t const * const buffer;           // input buffer this cursor traverses
-    st_trie_t const * const       trie;             // trie used for traversing virtual output buffer
+    const st_key_buffer_t * const buffer;           // input buffer this cursor traverses
+    const st_trie_t * const       trie;             // trie used for traversing virtual output buffer
     st_cursor_pos_t               cursor_pos;       // Contains all position info for the cursor
     st_trie_payload_t             cached_action;
     uint8_t                       cache_valid;
@@ -61,9 +60,9 @@ typedef struct
 
 typedef struct
 {
-    st_trie_payload_t   payload;
-    char                *sequence;
-    char                *transform;
+    st_trie_payload_t payload;
+    char * const      sequence;
+    char * const      transform;
 } st_trie_rule_t;
 
 typedef struct
@@ -79,7 +78,11 @@ typedef struct
 } st_trie_search_result_t;
 
 bool st_trie_get_completion(st_cursor_t *cursor, st_trie_search_result_t *res);
-bool st_trie_do_rule_searches(st_trie_t *trie, const st_key_buffer_t *key_buffer, int word_start_idx, st_trie_rule_t *rule);
+bool st_trie_do_rule_searches(const st_trie_t *trie,
+                              const st_key_buffer_t *key_buffer,
+                              st_key_stack_t *key_stack,
+                              int word_start_idx,
+                              st_trie_rule_t *rule);
 uint16_t st_get_trie_data_word(const st_trie_t *trie, int index);
 uint8_t st_get_trie_completion_byte(const st_trie_t *trie, int index);
 
@@ -88,11 +91,12 @@ uint8_t st_get_trie_completion_byte(const st_trie_t *trie, int index);
 
 typedef struct
 {
-    st_trie_t               *trie;                  // trie to search
-    const st_key_buffer_t   *key_buffer;            // search buffer
-    int                     search_end_ridx;        // reverse index to end of search window
-    int                     skip_levels;	        // number of trie levels to 'skip' when searching
-    st_trie_rule_t          *result;                // pointer to result to be filled with best match
+    const st_trie_t * const         trie;            // trie to search in
+    const st_key_buffer_t * const   key_buffer;      // key buffer to search with
+    st_key_stack_t * const          key_stack;       // stack for recording visited sequences
+    int                             search_end_ridx; // reverse index to end of search window
+    int                             skip_levels;	 // number of trie levels to 'skip' when searching
+    st_trie_rule_t * const          result;          // pointer to result to be filled with best match
 } st_trie_search_t;
 
 void st_get_payload_from_match_index(const st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);


### PR DESCRIPTION
As you know, variables are mutable by default in C. We must use `const` where appropriate for a couple main reasons:
1. To help the compiler optimize.
2. To prevent ourselves from writing functions that change things they shouldn't be changing.
3. To make it easier to read the code (and thus use it in new code). I know it may not look as pretty with those `const` everywhere, but it's a lot easier to understand code when you can quickly see what is mutable and what isn't. Example: when writing new code that uses an existing function, if we see that a function arg is `const`, we don't have to worry that the function will change our data.
4. Some struct members should be `read only`. Using `const` helps us do this, as the compiler will then complain any time we try to change these members after object creation.

So moving forward, let's always try to use const where appropriate. :)

Addressing #56, here are the changes in this PR:
1. Moved the key stack out of the trie struct. It's now a global and must be passed directly to functions that need a stack.
2. The global trie object can now be made const, so we can't accidentally change any of its members after creation.
3. Added const qualifiers to other objects and function params where appropriate.
6. Renamed `cursor->cursor_pos` to `cursor->pos`.