### PR TITLE
Rule search false positive fix

### DIFF
--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -275,8 +275,7 @@ __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_
 void st_find_missed_rule(void)
 {
 #if SEQUENCE_TRANSFORM_RULE_SEARCH
-    st_debug(ST_DBG_RULE_SEARCH,
-        "MISSED RULE SEARCH");
+    st_debug(ST_DBG_RULE_SEARCH, "START OF RULE SEARCH\n");
     char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
     char transform_str[TRANSFORM_MAX_LENGTH + 1] = {0};
     // find buffer index for the space before the last word,

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -27,6 +27,12 @@ static uint32_t backspace_timer = 0;
 
 #if SEQUENCE_TRANSFORM_RULE_SEARCH
 static bool post_process_do_rule_search = false;
+void schedule_rule_search(void)
+{
+    post_process_do_rule_search = true;
+}
+#else
+void schedule_rule_search(void){}
 #endif
 
 #define KEY_AT(i) st_key_buffer_get_triecode(&key_buffer, (i))
@@ -473,6 +479,7 @@ bool process_sequence_transform(uint16_t keycode,
     }
     // Don't process on key up
     if (!record->event.pressed) {
+        schedule_rule_search();
         return true;
     }
     // Convert keycode to KC_SPC if necessary
@@ -491,10 +498,6 @@ bool process_sequence_transform(uint16_t keycode,
     if (st_perform()) {
         // tell QMK to not process this key
         return false;
-    } else {
-#if SEQUENCE_TRANSFORM_RULE_SEARCH
-        post_process_do_rule_search = true;
-#endif
     }
     return true;
 }

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -280,8 +280,7 @@ __attribute__((weak)) void sequence_transform_on_missed_rule_user(const st_trie_
 //////////////////////////////////////////////////////////////////////
 void st_find_missed_rule(void)
 {
-#if SEQUENCE_TRANSFORM_RULE_SEARCH
-    st_debug(ST_DBG_RULE_SEARCH, "START OF RULE SEARCH\n");
+#if SEQUENCE_TRANSFORM_RULE_SEARCH    
     char sequence_str[SEQUENCE_MAX_LENGTH + 1] = {0};
     char transform_str[TRANSFORM_MAX_LENGTH + 1] = {0};
     // find buffer index for the space before the last word,
@@ -302,7 +301,6 @@ void st_find_missed_rule(void)
            KEY_AT(word_start_idx) != ' ') {
         ++word_start_idx;
     }
-    //uprintf("word_start_idx: %d\n", word_start_idx);
     st_trie_rule_t result = {{0}, sequence_str, transform_str};
     if (st_trie_do_rule_searches(&trie,
                                  &key_buffer,

--- a/tester/test_ascii_string.c
+++ b/tester/test_ascii_string.c
@@ -40,14 +40,11 @@ int test_ascii_string(const st_test_options_t *options)
         st_key_buffer_push(buf, st_keycode_to_triecode(key, TEST_KC_SEQ_TOKEN_0));
         st_key_buffer_print(buf);
         // let sequence transform do its thing!
-        if (st_perform()) {
-            // st_perform sent a transform to the output buffer
-            st_key_stack_print(&sim_output);
-            continue;
-        }
-        // st_perform didn't do anything special with this key,
-        // so we must add it to the output buffer
-        tap_code16(key);
+        if (!st_perform()) {
+            // st_perform didn't do anything special with this key,
+            // so we must add it to the output buffer
+            tap_code16(key);
+        }        
         st_key_stack_print(&sim_output);
         // check for missed rule
         missed_rule_seq[0] = 0;

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -66,7 +66,7 @@ bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transf
         // If trans_prefix is not in rule->transform,
         // this is an untestable rule.
         //char trans_prefix_str[128] = {0};
-        //triecodes_to_ascii_str(trans_prefix, trans_prefix_str);
+        //st_triecodes_to_ascii_str(trans_prefix, trans_prefix_str);
         //printf("trans_prefix %s is not in rule->transform!\n", trans_prefix_str);
         return false;
     }

--- a/tester/tester.c
+++ b/tester/tester.c
@@ -53,7 +53,9 @@ void tap_code16(uint16_t keycode)
 {
     switch (keycode) {
         case KC_BSPC:
-            st_key_stack_pop(&sim_output);
+            if (sim_output.size > 0) {
+                st_key_stack_pop(&sim_output);
+            }
             break;
         default:
         {

--- a/trie.c
+++ b/trie.c
@@ -183,6 +183,8 @@ bool st_trie_do_rule_searches(const st_trie_t       *trie,
                               int                   word_start_idx,
                               st_trie_rule_t        *rule)
 {
+    st_debug(ST_DBG_RULE_SEARCH,
+        "START OF RULE SEARCH - word_start_idx: %d\n", word_start_idx);
     // Convert word_start_index to reverse index
     const int search_base_ridx = st_clamp(key_buffer->size - word_start_idx,
                                           1, key_buffer->size - 1);
@@ -226,13 +228,14 @@ void debug_rule_match(const st_trie_payload_t *payload,
     const int seq_skips = 1 + payload->num_backspaces;
     const int search_base_ridx = search->search_end_ridx - seq_skips;
     const int transform_end_ridx = search_base_ridx + payload->completion_len;
-    uprintf("  checking match @%d, transform_end_ridx: %d (%send), stack: |%s|, comp: |%s|(%d bs)\n",
-            offset,
-            transform_end_ridx,
-            transform_end_ridx != key_buffer->size ? "!" : "",
-            stackstr,
-            compstr,
-            payload->num_backspaces);
+    st_debug(ST_DBG_RULE_SEARCH,
+        "  checking match @%d, transform_end_ridx: %d (%send), stack: |%s|, comp: |%s|(%d bs)\n",
+        offset,
+        transform_end_ridx,
+        transform_end_ridx != key_buffer->size ? "!" : "",
+        stackstr,
+        compstr,
+        payload->num_backspaces);
 #endif
 }
 //////////////////////////////////////////////////////////////////////

--- a/trie.c
+++ b/trie.c
@@ -284,7 +284,7 @@ bool st_trie_rule_search(st_trie_search_t *search, uint16_t offset)
         for (; code; offset += 3, code = TDATA(trie, offset)) {
             if (!check || cur_key == code) {
                 // Get 16bit offset to child node
-                const uint16_t child_offset = (TDATA(trie, offset + 1) << 8) + TDATA(trie, offset + 2);
+                const uint16_t child_offset = TDATAW(trie, offset+1);
                 // Traverse down child node
                 st_key_stack_push(key_stack, code);
                 res = st_trie_rule_search(search, child_offset) || res;

--- a/trie.h
+++ b/trie.h
@@ -91,12 +91,13 @@ uint8_t  st_get_trie_completion_byte(const st_trie_t *trie, int index);
 
 typedef struct
 {
-    const st_trie_t * const         trie;            // trie to search in
-    const st_key_buffer_t * const   key_buffer;      // key buffer to search with
-    st_key_stack_t * const          key_stack;       // stack for recording visited sequences
-    int                             search_end_ridx; // reverse index to end of search window
-    int                             skip_levels;	 // number of trie levels to 'skip' when searching
-    st_trie_rule_t * const          result;          // pointer to result to be filled with best match
+    const st_trie_t * const         trie;               // trie to search in
+    const st_key_buffer_t * const   key_buffer;         // key buffer to search with
+    st_key_stack_t * const          key_stack;          // stack for recording visited sequences
+    int                             search_end_ridx;    // reverse index to end of search window
+    int                             search_max_seq_len; // length of longest matching sequence
+    int                             skip_levels;	    // number of trie levels to 'skip' when searching
+    st_trie_rule_t * const          result;             // pointer to result to be filled with best match
 } st_trie_search_t;
 
 void st_get_payload_from_match_index(const st_trie_t *trie, st_trie_payload_t *payload, uint16_t trie_match_index);


### PR DESCRIPTION
This fixes rule search so that it doesn't report false positive matches when more context would have triggered a different rule.
Example:
```
1. ␣i☆     ⇒ I'm
2. i☆      ⇒ ious
```
Before, typing `␣ious` was reporting rule 1. This was incorrect.

Rule search is now scheduled on key up, instead of only after non sequence token keys. This helps it find more rules.