### PR TITLE
include st_defaults.h from sequence_transform.h

### DIFF
--- a/sequence_transform.h
+++ b/sequence_transform.h
@@ -8,6 +8,7 @@
 // Original source/inspiration: https://getreuer.info/posts/keyboards/autocorrection
 #pragma once
 
+#include "st_defaults.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include "action.h"


### PR DESCRIPTION
User should only have to include `sequence_transform.h` to use our lib, so that file should include `st_defaults.h`.