### PR TITLE
[CLEANUP] Trailing backspace cleanup

### DIFF
--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -647,8 +647,8 @@ def generate_sequence_transform_data(data_header_file, test_header_file):
         f'#define SEQUENCE_TRIE_SIZE {len(trie_data)}',
         f'#define COMPLETIONS_SIZE {len(completions_data)}',
         f'#define SEQUENCE_TOKEN_COUNT {len(SEQ_TOKEN_SYMBOLS)}',
-        '',        
-        st_seq_token_ascii_chars,        
+        '',
+        st_seq_token_ascii_chars,
         st_wordbreak_ascii,
         # qmk build checks for unused vars,
         # so we must use an ifdef here

--- a/st_debug.h
+++ b/st_debug.h
@@ -35,5 +35,5 @@ const char  **st_debug_get_flag_names(void);
 #define st_debug_check(flag)     \
     (SEQUENCE_TRANSFORM_DEBUG && \
      st_debug_test_flag(flag))
-    
+
 

--- a/tester/Makefile
+++ b/tester/Makefile
@@ -11,7 +11,7 @@ LIB_DIR			:= ../
 TESTER_DIR		:= ./
 LIB_SOURCES		:= $(wildcard $(LIB_DIR)/*.c)
 LIB_OBJECTS		:= $(LIB_SOURCES:$(LIB_DIR)/%.c=$(ODIR)/%.o)
-TESTER_SOURCES	:= $(wildcard $(TESTER_DIR)/*.c) 
+TESTER_SOURCES	:= $(wildcard $(TESTER_DIR)/*.c)
 TESTER_OBJECTS	:= $(TESTER_SOURCES:$(TESTER_DIR)/%.c=$(ODIR)/%.o) $(LIB_OBJECTS)
 DEPENDS			:= $(TESTER_OBJECTS:%.o=%.d)
 
@@ -47,7 +47,7 @@ $(ST_GEN_OUT): $(ST_GEN_IN)
 	@echo Running generator
 	$(PYTHON) $(ST_GEN_PY) -c $(ST_CONFIG)
 
-gen: $(ST_GEN_OUT) 
+gen: $(ST_GEN_OUT)
 
 tester: $(TESTER_OBJECTS)
 	@$(CC) -o $@ $^ $(CFLAGS)
@@ -59,7 +59,7 @@ $(ODIR)/%.o: %.c | $(ODIR)
 	@echo Compiling $<
 	@$(CC) -MMD -c -o $@ $< $(CFLAGS)
 
-$(ODIR): 
+$(ODIR):
 	@mkdir -p $@
 
 .PHONY: clean

--- a/tester/test_ascii_string.c
+++ b/tester/test_ascii_string.c
@@ -22,7 +22,7 @@ int test_ascii_string(const st_test_options_t *options)
     st_key_stack_reset(&sim_output);
     // we don't use st_key_buffer_reset(buf) here because
     // we don't nec want a space at the start of the buffer
-    st_key_buffer_t *buf = st_get_key_buffer();    
+    st_key_buffer_t *buf = st_get_key_buffer();
     buf->size = 0;
     for (int i = 0; i < len; ++i) {
         const char c = options->user_str[i];
@@ -44,7 +44,7 @@ int test_ascii_string(const st_test_options_t *options)
             // st_perform didn't do anything special with this key,
             // so we must add it to the output buffer
             tap_code16(key);
-        }        
+        }
         st_key_stack_print(&sim_output);
         // check for missed rule
         missed_rule_seq[0] = 0;

--- a/tester/test_find_rule.c
+++ b/tester/test_find_rule.c
@@ -61,7 +61,7 @@ bool setup_input_from_transform(const st_test_rule_t *rule, char *chained_transf
     // input now contains seq_prefix (^d@)
     // output now contains trans_prefix (develop)
     sim_output.buffer[sim_output.size] = 0;
-    const uint8_t *trans_prefix = &sim_output.buffer[0];    
+    const uint8_t *trans_prefix = &sim_output.buffer[0];
     if (!strstr((char*)rule->transform, (char*)trans_prefix)) {
         // If trans_prefix is not in rule->transform,
         // this is an untestable rule.
@@ -96,7 +96,7 @@ void test_find_rule(const st_test_rule_t *rule, st_test_result_t *res)
     // rule search starts looking from the last space in the buffer
     // so if there is a space in the rule transform,
     // this rule is untestable (except if space is at the start or end)
-    char *space = strchr((char*)rule->transform, ' ');   
+    char *space = strchr((char*)rule->transform, ' ');
     if (space) {
         const int transform_len = strlen((char*)rule->transform);
         const int space_idx = space - (char*)rule->transform;

--- a/tester/test_perform.c
+++ b/tester/test_perform.c
@@ -20,7 +20,7 @@ void sim_st_perform(const uint8_t *sequence)
     // we don't use st_key_buffer_reset(buf) here because
     // we don't nec want a space at the start of the buffer
     st_key_buffer_t *buf = st_get_key_buffer();
-    buf->size = 0;    
+    buf->size = 0;
     for (uint8_t triecode = *sequence; triecode; triecode = *++sequence) {
         st_key_buffer_push(buf, triecode);
         // If st_perform doesn't do anything special with this key,

--- a/trie.c
+++ b/trie.c
@@ -329,7 +329,7 @@ bool st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
     const st_key_buffer_t *key_buffer = search->key_buffer;
     st_trie_rule_t *res = search->result;
     // After removing 'skipped' keys (trigger and backspaces),
-    // check that the stack matches the input buffer.    
+    // check that the stack matches the input buffer.
     const int seq_skips = 1 + payload->num_backspaces;
     const int search_base_ridx = search->search_end_ridx - seq_skips;
     st_debug(ST_DBG_RULE_SEARCH, "    testing stack:");
@@ -347,7 +347,7 @@ bool st_check_rule_match(const st_trie_payload_t *payload, st_trie_search_t *sea
     // Record search_max_seq_len so we can avoid reporting
     // false positives during this run that have shorter sequences
     st_debug(ST_DBG_RULE_SEARCH, " potential match! seq_len: %d\n", key_stack->size);
-    search->search_max_seq_len = key_stack->size;    
+    search->search_max_seq_len = key_stack->size;
     // Early return if potential transform doesn't reach end of search buffer
     const int transform_end_ridx = search_base_ridx + payload->completion_len;
     if (transform_end_ridx != key_buffer->size) {


### PR DESCRIPTION
Just a simple pr to remove trailing backspaces, `not sure` if `make` cares for them, I built a tester and it worked just fine, but I'm not a make expert