### PR TITLE
[BUGFIX] Use triecode instead of keycode in key_buffer initialization.

### DIFF
--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -40,7 +40,7 @@ void schedule_rule_search(void){}
 //////////////////////////////////////////////////////////////////
 // Key history buffer
 #define KEY_BUFFER_CAPACITY MIN(255, SEQUENCE_MAX_LENGTH + COMPLETION_MAX_LENGTH + SEQUENCE_TRANSFORM_EXTRA_BUFFER)
-static st_key_action_t key_buffer_data[KEY_BUFFER_CAPACITY] = {{KC_SPC, ST_DEFAULT_KEY_ACTION}};
+static st_key_action_t key_buffer_data[KEY_BUFFER_CAPACITY] = {{' ', ST_DEFAULT_KEY_ACTION}};
 static st_key_buffer_t key_buffer = {
     key_buffer_data,
     KEY_BUFFER_CAPACITY,

--- a/sequence_transform.c
+++ b/sequence_transform.c
@@ -44,7 +44,8 @@ static st_key_action_t key_buffer_data[KEY_BUFFER_CAPACITY] = {{' ', ST_DEFAULT_
 static st_key_buffer_t key_buffer = {
     key_buffer_data,
     KEY_BUFFER_CAPACITY,
-    1
+    1,
+    0
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We didn't update the key_buffer initializer to use the triecode for space instead of the keycode. This epic PR fixes that