### PR TITLE
[BUGFIX] Fix missing empty completion in outputs dict

### DIFF
--- a/generator/sequence_transform_data.py
+++ b/generator/sequence_transform_data.py
@@ -234,6 +234,7 @@ def make_sequence_trie(
 ###############################################################################
 def complete_sequence_trie(trie: Dict[str, Any], wordbreak_symbol: str) -> set[str]:
     outputs = set()
+    outputs.add("")
 
     def complete_node(sequence, action):
         nonlocal outputs


### PR DESCRIPTION
If the defined rules didn't have any rules that required an empty completion, the auto-generated default rules would cause a crash in the generator, because they didn't add the empty string to the set of completions. Since adding the empty string to that set never adds anything unneeded, we now just add it immediately when creating the set.